### PR TITLE
fix: prevent the java compiler from optimizing away the API level check

### DIFF
--- a/Stubs/src/main/java/android/os/Build.java
+++ b/Stubs/src/main/java/android/os/Build.java
@@ -1,5 +1,7 @@
 package android.os;
 
+import java.util.Random;
+
 public class Build {
 
   public static final String MODEL = null;
@@ -7,13 +9,13 @@ public class Build {
   public static class VERSION {
 
     public static final String RELEASE = null;
-    public static final int SDK_INT = 0;
+    public static final int SDK_INT = new Random().nextInt();
 
   }
 
   public static class VERSION_CODES {
 
-    public static final int JELLY_BEAN = 0;
+    public static final int JELLY_BEAN = new Random().nextInt();
 
   }
 }


### PR DESCRIPTION
# Description 

`android.os.Build` in `Stubs` has constant values for `SDK_INT`, so the
java compiler will inline the branch of the if condition in `EnvironmentInfo`
in other words this:

```java
if(VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN) {
  this.deviceTotalMemory = Math.round((double)getMemoryInfo(this.activityManager).totalMem / 1048576.0D);
} else {
  this.deviceTotalMemory = -1L;
}
```

turns into:

```
this.deviceTotalMemory = Math.round((double)getMemoryInfo(this.activityManager).totalMem / 1048576.0D);
```

in byte code.

To prevent this compiler optimization I populate the values with `Random#nextInt`
so the compiler can't know the values yet. We only compile agains `Stubs`
at runtime our lib uses the actual android platform, so this change in
`Stubs` has no impact on the runtime behavior.

fixes REM-25622

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
