### PR TITLE
fix: Hard code Build.VERSION_CODES.JELLY_BEAN to avoid crash on lower…

### DIFF
--- a/Core/src/main/java/com/rakuten/tech/mobile/perf/core/EnvironmentInfo.java
+++ b/Core/src/main/java/com/rakuten/tech/mobile/perf/core/EnvironmentInfo.java
@@ -32,7 +32,8 @@ class EnvironmentInfo implements Observer {
     this.osVersion = Build.VERSION.RELEASE;
     this.activityManager = (ActivityManager) context.getSystemService(Activity.ACTIVITY_SERVICE);
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+    // Hard code Build.VERSION_CODES.JELLY_BEAN to avoid crash on lower os version.
+    if (Build.VERSION.SDK_INT >= 16) {
       this.deviceTotalMemory = Math.round((double) (getMemoryInfo(activityManager).totalMem) / (double) MEGA_BYTE);
     } else {
       this.deviceTotalMemory = -1L;

--- a/Stubs/src/main/java/android/os/Build.java
+++ b/Stubs/src/main/java/android/os/Build.java
@@ -12,10 +12,4 @@ public class Build {
     public static final int SDK_INT = new Random().nextInt();
 
   }
-
-  public static class VERSION_CODES {
-
-    public static final int JELLY_BEAN = new Random().nextInt();
-
-  }
 }


### PR DESCRIPTION
# Description 

Hard code Build.VERSION_CODES.JELLY_BEAN to avoid crash on lower os version.

fixes REM-25622

## Links
Add links to github/jira issues, design documents and other relevant resources (e.g. previous discussions, platform/tool documentation etc.)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
