### PR TITLE
test: wait longer for thread to die so test is less flaky (hopefully)

### DIFF
--- a/Core/src/test/java/com/rakuten/tech/mobile/perf/core/SenderThreadSpec.java
+++ b/Core/src/test/java/com/rakuten/tech/mobile/perf/core/SenderThreadSpec.java
@@ -235,7 +235,7 @@ public class SenderThreadSpec {
 
       senderThread.start();
 
-      Thread.sleep(10); // give the thread some time to die
+      Thread.sleep(100); // give the thread some time to die
 
       assertThat(senderThread.isAlive()).isFalse();
     }


### PR DESCRIPTION
# Description 
`master` fails to build because some tests fail. The failing tests rely on `Thread#sleep` and run successfully on dev machines, so I increased the wait time for the CI machine hoping it'll workaround that inherent flakiness.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
