### PR TITLE
Fix: app debuggable check ignores properties order of certification p…

### DIFF
--- a/Runtime/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/Util.java
+++ b/Runtime/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/Util.java
@@ -27,8 +27,6 @@ public final class Util {
   private static final String SUBSCRIPTION_META_KEY =
       "com.rakuten.tech.mobile.relay.SubscriptionKey";
   private static final String RELAY_APP_ID = "com.rakuten.tech.mobile.relay.AppId";
-  private static final X500Principal DEBUG_DN = new X500Principal(
-      "C=US, O=Android, CN=Android Debug");
 
   private Util() {
   }
@@ -107,8 +105,10 @@ public final class Util {
       for (Signature signature : signatures) {
         ByteArrayInputStream stream = new ByteArrayInputStream(signature.toByteArray());
         X509Certificate cert = (X509Certificate) certificateFactory.generateCertificate(stream);
-        boolean debuggable = DEBUG_DN.equals(cert.getSubjectX500Principal());
-        if (debuggable) {
+        String principal = cert.getSubjectX500Principal().toString();
+        if (principal.contains("C=US") &&
+            principal.contains("O=Android") &&
+            principal.contains("CN=Android Debug")) {
           return true;
         }
       }


### PR DESCRIPTION
…rincipal.

# Description
* Different Android Studio version generate debug keystore with different orders of principal properties. This let to failed detecting of debuggable app.

## Links
https://jira.rakuten-it.com/jira/browse/REM-25888

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
