### PR TITLE
Fix: error http status code is not recorded when get input stream is …

### DIFF
--- a/Core/src/main/java/com/rakuten/tech/mobile/perf/core/wrappers/HttpURLConnectionWrapper.java
+++ b/Core/src/main/java/com/rakuten/tech/mobile/perf/core/wrappers/HttpURLConnectionWrapper.java
@@ -98,11 +98,6 @@ public class HttpURLConnectionWrapper extends HttpURLConnection {
     _conn.setFixedLengthStreamingMode(contentLength);
   }
 
-  //@Override
-  //public void setFixedLengthStreamingMode(long contentLength) {
-  //    _conn.setFixedLengthStreamingMode(contentLength);
-  //}
-
   @Override
   public void setInstanceFollowRedirects(boolean followRedirects) {
     _conn.setInstanceFollowRedirects(followRedirects);
@@ -164,11 +159,6 @@ public class HttpURLConnectionWrapper extends HttpURLConnection {
   public int getContentLength() {
     return _conn.getContentLength();
   }
-
-  //@Override
-  //public long getContentLengthLong() {
-  //    return _conn.getContentLengthLong();
-  //}
 
   @Override
   public String getContentType() {
@@ -247,22 +237,30 @@ public class HttpURLConnectionWrapper extends HttpURLConnection {
       _state = STARTED;
     }
 
-    InputStream stream = _conn.getInputStream();
     int statusCode = _conn.getResponseCode();
+    try {
+      InputStream stream = _conn.getInputStream();
 
-    if (stream == null) {
+      if (stream == null) {
+        if (_state == STARTED) {
+          Tracker.endUrl(_id, statusCode);
+          _state = ENDED;
+        }
+        return null;
+      }
+
+      if (_state == STARTED) {
+        _state = INPUT;
+      }
+
+      return new HttpInputStreamWrapper(stream, _id, statusCode);
+    } catch (IOException e) {
       if (_state == STARTED) {
         Tracker.endUrl(_id, statusCode);
         _state = ENDED;
       }
-      return null;
+      throw e;
     }
-
-    if (_state == STARTED) {
-      _state = INPUT;
-    }
-
-    return new HttpInputStreamWrapper(stream, _id, statusCode);
   }
 
   @Override

--- a/Core/src/main/java/com/rakuten/tech/mobile/perf/core/wrappers/HttpsURLConnectionWrapper.java
+++ b/Core/src/main/java/com/rakuten/tech/mobile/perf/core/wrappers/HttpsURLConnectionWrapper.java
@@ -150,11 +150,6 @@ public class HttpsURLConnectionWrapper extends HttpsURLConnection {
     _conn.setFixedLengthStreamingMode(contentLength);
   }
 
-  //@Override
-  //public void setFixedLengthStreamingMode(long contentLength) {
-  //    _conn.setFixedLengthStreamingMode(contentLength);
-  //}
-
   @Override
   public void setInstanceFollowRedirects(boolean followRedirects) {
     _conn.setInstanceFollowRedirects(followRedirects);
@@ -216,11 +211,6 @@ public class HttpsURLConnectionWrapper extends HttpsURLConnection {
   public int getContentLength() {
     return _conn.getContentLength();
   }
-
-  //@Override
-  //public long getContentLengthLong() {
-  //    return _conn.getContentLengthLong();
-  //}
 
   @Override
   public String getContentType() {
@@ -299,22 +289,30 @@ public class HttpsURLConnectionWrapper extends HttpsURLConnection {
       _state = STARTED;
     }
 
-    InputStream stream = _conn.getInputStream();
     int statusCode = _conn.getResponseCode();
+    try {
+      InputStream stream = _conn.getInputStream();
 
-    if (stream == null) {
+      if (stream == null) {
+        if (_state == STARTED) {
+          Tracker.endUrl(_id, statusCode);
+          _state = ENDED;
+        }
+        return null;
+      }
+
       if (_state == STARTED) {
-        Tracker.endUrl(_id, _conn.getResponseCode());
+        _state = INPUT;
+      }
+
+      return new HttpInputStreamWrapper(stream, _id, statusCode);
+    } catch (IOException e) {
+      if (_state == STARTED) {
+        Tracker.endUrl(_id, statusCode);
         _state = ENDED;
       }
-      return null;
+      throw e;
     }
-
-    if (_state == STARTED) {
-      _state = INPUT;
-    }
-
-    return new HttpInputStreamWrapper(stream, _id, statusCode);
   }
 
   @Override


### PR DESCRIPTION
…called on URL connection

# Description 
Try catch IOException inside getInputStream(), to get and set error http status code.

## Links
https://jira.rakuten-it.com/jira/browse/REM-25614

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
