### PR TITLE
Fix: app debuggable check ignores CN order of certification principal.

### DIFF
--- a/Runtime/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/Util.java
+++ b/Runtime/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/Util.java
@@ -15,7 +15,6 @@ import android.support.annotation.VisibleForTesting;
 import java.io.ByteArrayInputStream;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import javax.security.auth.x500.X500Principal;
 
 /**
  * Shared functions for Relay SDKs.
@@ -27,8 +26,6 @@ public final class Util {
   private static final String SUBSCRIPTION_META_KEY =
       "com.rakuten.tech.mobile.relay.SubscriptionKey";
   private static final String RELAY_APP_ID = "com.rakuten.tech.mobile.relay.AppId";
-  private static final X500Principal DEBUG_DN = new X500Principal(
-      "C=US, O=Android, CN=Android Debug");
 
   private Util() {
   }
@@ -95,7 +92,7 @@ public final class Util {
    */
   @RestrictTo(LIBRARY)
   @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
-  public static boolean isAppDebuggable(@NonNull final Context context) {
+  static boolean isAppDebuggable(@NonNull final Context context) {
     try {
       PackageManager packageManager = context.getPackageManager();
       PackageInfo packageInfo = packageManager
@@ -107,10 +104,8 @@ public final class Util {
       for (Signature signature : signatures) {
         ByteArrayInputStream stream = new ByteArrayInputStream(signature.toByteArray());
         X509Certificate cert = (X509Certificate) certificateFactory.generateCertificate(stream);
-        boolean debuggable = DEBUG_DN.equals(cert.getSubjectX500Principal());
-        if (debuggable) {
-          return true;
-        }
+        String principal = cert.getSubjectX500Principal().toString().toUpperCase();
+        return principal.contains("C=US") && principal.contains("O=ANDROID") && principal.contains("CN=ANDROID DEBUG");
       }
     } catch (Exception e) {
       // Things went south, anyway the app is not debuggable.

--- a/Runtime/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/UtilSpec.java
+++ b/Runtime/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/UtilSpec.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.Signature;
 import com.rakuten.tech.mobile.perf.runtime.RobolectricUnitSpec;
 import com.rakuten.tech.mobile.perf.runtime.TestRawData;
@@ -57,6 +58,14 @@ public class UtilSpec extends RobolectricUnitSpec {
   @Test
   public void shouldReturnFalseIfSignatureIsMissing()
       throws PackageManager.NameNotFoundException {
+
+    assertThat(Util.isAppDebuggable(context)).isFalse();
+  }
+
+  @Test
+  public void shouldReturnFalseIfExceptionOccurs()
+      throws PackageManager.NameNotFoundException {
+    when(packageManager.getPackageInfo(anyString(), anyInt())).thenThrow(new NameNotFoundException());
 
     assertThat(Util.isAppDebuggable(context)).isFalse();
   }


### PR DESCRIPTION
* Different Android Studio version generate debug keystore with different orders of CN properties. This let to failed detecting of debuggable app.

https://jira.rakuten-it.com/jira/browse/REM-25888

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
