### PR TITLE
include crash reporting as dependency

### DIFF
--- a/Plugin/src/main/groovy/com/rakuten/tech/mobile/perf/PerfPlugin.groovy
+++ b/Plugin/src/main/groovy/com/rakuten/tech/mobile/perf/PerfPlugin.groovy
@@ -49,6 +49,10 @@ class PerfPlugin implements Plugin<Project> {
           url repository
         }
       }
+
+      dependencies {
+        compile 'com.rakuten.tech.mobile:crash-reporting-plugin:0.3.0'
+      }
     }
 
     project.dependencies.compile runtime


### PR DESCRIPTION
# Description 
Include crash reporting as dependency.

## Links
Add links to github/jira issues, design documents and other relevant resources (e.g. previous discussions, platform/tool documentation etc.)

# Checklist
- [ ] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [ ] I ran `./gradlew check` without errors
