### PR TITLE
Fixing broken integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "Runtime/build.gradle" }}-{{ checksum  "Plugin/build.gradle" }}-{{ checksum  "Core/build.gradle" }}-{{ checksum  "Stubs/build.gradle" }}
       - run:
           name: Run Tests
-          command: ./gradlew check --info
+          command: ./gradlew check --stacktrace
       - store_artifacts:
           path: ~/code/Plugin/build/reports
           destination: plugin-reports/

--- a/Plugin/src/test/groovy/com/rakuten/tech/mobile/perf/PerfPluginExtensionIntegrationSpec.groovy
+++ b/Plugin/src/test/groovy/com/rakuten/tech/mobile/perf/PerfPluginExtensionIntegrationSpec.groovy
@@ -26,7 +26,7 @@ public class PerfPluginExtensionIntegrationSpec extends IntegrationSpec {
     buildFile << resourceFile("example_app_ext_all_enabled").text
     def result = GradleRunner.create()
         .withProjectDir(projectDir.root)
-        .withArguments('assembleDebug', '--debug', '--refresh-dependencies')
+        .withArguments('assembleDebug', '--debug', '--offline')
         .build()
 
     assert result.task(':transformClassesWithPerfTrackingForDebug').outcome == TaskOutcome.SUCCESS

--- a/Plugin/src/test/groovy/com/rakuten/tech/mobile/perf/PerfPluginExtensionIntegrationSpec.groovy
+++ b/Plugin/src/test/groovy/com/rakuten/tech/mobile/perf/PerfPluginExtensionIntegrationSpec.groovy
@@ -26,7 +26,7 @@ public class PerfPluginExtensionIntegrationSpec extends IntegrationSpec {
     buildFile << resourceFile("example_app_ext_all_enabled").text
     def result = GradleRunner.create()
         .withProjectDir(projectDir.root)
-        .withArguments('assembleDebug', '--debug')
+        .withArguments('assembleDebug', '--debug', '--refresh-dependencies')
         .build()
 
     assert result.task(':transformClassesWithPerfTrackingForDebug').outcome == TaskOutcome.SUCCESS


### PR DESCRIPTION
# Description 
For some reason the integration tests run within gradle test kit fail on circle CI

## Links
* https://circleci.com/gh/rakutentech/android-perftracking/96#artifacts/containers/0
* https://96-108369600-gh.circle-artifacts.com/0/plugin-reports/tests/test/classes/com.rakuten.tech.mobile.perf.PerfPluginExtensionIntegrationSpec.html#plugin should use dummy rewriter for debug build config missing


# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
