### PR TITLE
ci: add test summary config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,4 +34,10 @@ jobs:
       - store_artifacts:
           path: ~/code/Core/build/reports
           destination: core-reports/
+      - store_test_results:
+          path: ~/code/Plugin/build/test-results/test
+      - store_test_results:
+          path: ~/code/Runtime/build/test-results/testReleaseUnitTest
+      - store_test_results:
+          path: ~/code/Core/build/test-results/test
       - run: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
# Description 
This should show a test summary in circle ci builds.

## Links
https://circleci.com/docs/2.0/configuration-reference/#store_test_results

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
