### PR TITLE
fix: try to work around the jcenter 304 responses breaking circleci

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,9 @@ import com.rakuten.tech.tool.CheckGradleFilesForSnapshotDependencies
 buildscript {
   apply from: "config/index.gradle"
   repositories {
-    jcenter()
+    // try to work around jcenters akamai misconfiguration issue
+    // see https://github.com/gradle/gradle/issues/4703
+    jcenter { url "http://jcenter.bintray.com" }
     maven { url 'https://maven.google.com' }
     maven { url "https://plugins.gradle.org/m2/" }
   }


### PR DESCRIPTION
# Description 
Apparently jcenter's akamai layer is misconfigured which causes circle ci to fail with 

```
:Plugin:compileJava (Thread[main,5,main]) completed. Took 5.866 secs.

FAILURE: Build failed with an exception.

* What went wrong:
Could not resolve all files for configuration ':Plugin:compileClasspath'.
> Could not download httpclient.jar (org.apache.httpcomponents:httpclient:4.1.1)
   > Could not get resource 'https://jcenter.bintray.com/org/apache/httpcomponents/httpclient/4.1.1/httpclient-4.1.1.jar'.
      > Response 304: Not Modified has no content!
```

like in [build 108](https://circleci.com/gh/rakutentech/android-perftracking/108).
This PR tries to apply the workaround suggested in issue [4703 reported to gradle](https://github.com/gradle/gradle/issues/4703).

## Links
* https://circleci.com/gh/rakutentech/android-perftracking/108
* https://github.com/gradle/gradle/issues/4703

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
