### PR TITLE
Revert "Merge pull request #21 from NemoOudeis/ci/jcenter_304_akamai_…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,7 @@ import com.rakuten.tech.tool.CheckGradleFilesForSnapshotDependencies
 buildscript {
   apply from: "config/index.gradle"
   repositories {
-    // try to work around jcenters akamai misconfiguration issue
-    // see https://github.com/gradle/gradle/issues/4703
-    jcenter { url "http://jcenter.bintray.com" }
+    jcenter()
     maven { url 'https://maven.google.com' }
     maven { url "https://plugins.gradle.org/m2/" }
   }


### PR DESCRIPTION
…issue"

This reverts commit fa9ceb5bf072b4c2e2d264311fb3a2fea98551af, reversing
changes made to 29f24ec547aab0856edfb6cf1d1f7374305d785a.

# Description 
in https://github.com/rakutentech/android-perftracking/pull/21 I tried to work around jcenter's misconfiguration of akamai caching. It did not work relibaly and the situation is resolved now. 

## Links
See https://github.com/gradle/gradle/issues/4703

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
