### PR TITLE
Fix/do not send non metric measurements

### DIFF
--- a/Core/src/main/java/com/rakuten/tech/mobile/perf/core/Sender.java
+++ b/Core/src/main/java/com/rakuten/tech/mobile/perf/core/Sender.java
@@ -13,12 +13,15 @@ class Sender {
   private final Debug _debug;
   private Metric _metric;
   private int _sent;
+  private boolean sendMeasurementWithoutMetric;
 
-  Sender(MeasurementBuffer buffer, Current current, EventWriter writer, Debug debug) {
+  Sender(MeasurementBuffer buffer, Current current, EventWriter writer,
+      Debug debug, boolean sendMeasurementWithoutMetric) {
     _buffer = buffer;
     _current = current;
     _writer = writer;
     _debug = debug;
+    this.sendMeasurementWithoutMetric = sendMeasurementWithoutMetric;
   }
 
   /**
@@ -114,7 +117,13 @@ class Sender {
             _metric.urls++;
           }
 
-          send(m, _metric != null ? _metric.id : null);
+          // When `enableNonMetricMeasurements` from the config is false, measurements with
+          // no metric should not even be added to the buffer. However, they occasionally are due
+          // to threading issues, so this check is needed to prevent them from being sent
+          if (sendMeasurementWithoutMetric || _metric != null) {
+            send(m, _metric != null ? _metric.id : null);
+          }
+
           m.clear();
         }
       }

--- a/Core/src/main/java/com/rakuten/tech/mobile/perf/core/Tracker.java
+++ b/Core/src/main/java/com/rakuten/tech/mobile/perf/core/Tracker.java
@@ -29,7 +29,7 @@ public class Tracker {
     _tracker = new TrackerImpl(buffer, current, debug, config.enableNonMetricMeasurement);
     EnvironmentInfo envInfo = new EnvironmentInfo(context, locationObservable, batteryInfoObservable);
     EventWriter writer = new EventWriter(config, envInfo);
-    Sender sender = new Sender(buffer, current, writer, debug);
+    Sender sender = new Sender(buffer, current, writer, debug, config.enableNonMetricMeasurement);
     _senderThread = new SenderThread(sender);
     _senderThread.start();
   }

--- a/Core/src/test/java/com/rakuten/tech/mobile/perf/core/SenderSpec.java
+++ b/Core/src/test/java/com/rakuten/tech/mobile/perf/core/SenderSpec.java
@@ -29,7 +29,7 @@ public class SenderSpec {
     MockitoAnnotations.initMocks(this);
     measurementBuffer = new MeasurementBuffer();
     current = new Current();
-    sender = new Sender(measurementBuffer, current, eventWriter, new Debug());
+    sender = new Sender(measurementBuffer, current, eventWriter, new Debug(), true);
   }
 
   @Test public void shouldSendMeasurements() throws IOException {
@@ -45,7 +45,7 @@ public class SenderSpec {
   }
 
   @Test public void shouldNotFailSendingMeasurementWhenDebugIsNull() throws IOException {
-    sender = new Sender(measurementBuffer, current, eventWriter, null);
+    sender = new Sender(measurementBuffer, current, eventWriter, null, true);
     setUpCustomMeasurements(measurementBuffer, 10);
     sender.send(0);
     verify(eventWriter, times(1)).begin();
@@ -66,7 +66,7 @@ public class SenderSpec {
   }
 
   @Test public void shouldNotFailSendingMetricWhenDebugIsNull() throws IOException {
-    sender = new Sender(measurementBuffer, current, eventWriter, null);
+    sender = new Sender(measurementBuffer, current, eventWriter, null, true);
     setUp10CustomMetric(measurementBuffer);
     sender.send(0);
     verify(eventWriter, times(1)).begin();
@@ -186,6 +186,25 @@ public class SenderSpec {
     for (int i = startIndex; i < measurementBuffer.nextTrackingId.get(); i++) {
       assertThat(measurementBuffer.at[i]).is(cleared()); // all previous measurement are cleared
     }
+  }
+
+  @Test public void shouldNotSendMeasurementsWithoutAMetricWhenNonMetricMeasurementsDisabled() throws IOException {
+    sender = new Sender(measurementBuffer, current, eventWriter, new Debug(), false);
+    setUpCustomMeasurements(measurementBuffer, 10);
+
+    sender.send(0);
+
+    verify(eventWriter, never()).begin();
+  }
+
+  @Test public void shouldSendMeasurementsWithAMetricWhenNonMetricMeasurementsDisabled() throws IOException {
+    sender = new Sender(measurementBuffer, current, eventWriter, new Debug(), false);
+    setUp10CustomMetric(measurementBuffer);
+    setUpCustomMeasurements(measurementBuffer, 10);
+
+    sender.send(0);
+
+    verify(eventWriter, times(10)).write((Measurement) any(), (String) any());
   }
 
     /* setup test fixtures */

--- a/Core/src/test/java/com/rakuten/tech/mobile/perf/core/SenderThreadSpec.java
+++ b/Core/src/test/java/com/rakuten/tech/mobile/perf/core/SenderThreadSpec.java
@@ -136,7 +136,7 @@ public class SenderThreadSpec {
     @Before public void init() {
       MockitoAnnotations.initMocks(this);
       buffer = new MeasurementBuffer();
-      Sender sender = new Sender(buffer, new Current(), writer, null);
+      Sender sender = new Sender(buffer, new Current(), writer, null, true);
       senderThread = new SenderThread(sender, 10);
     }
 
@@ -208,7 +208,7 @@ public class SenderThreadSpec {
       writer = new EventWriter(config, envInfo, url);
 
       buffer = new MeasurementBuffer();
-      Sender sender = new Sender(buffer, new Current(), writer, null);
+      Sender sender = new Sender(buffer, new Current(), writer, null, true);
       senderThread = new SenderThread(sender, 10);
       populateBufferRunnable = new Runnable() {
         @Override


### PR DESCRIPTION
# Description 
The original implementation of preventing measurements from being added to the buffer when there isn't a metric seems to have some thread issues. Sometimes measurements get added even when there is no longer a metric. This fix prevents any measurements from being sent by the `Sender` with a null `Metric`.

## Links
APTT-291

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
