### PR TITLE
feat: Send OS Version and Device Model to config API

### DIFF
--- a/Runtime/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigStore.java
+++ b/Runtime/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigStore.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
@@ -89,6 +90,8 @@ class ConfigStore extends Store<ConfigurationResult> {
           .setCountryCode(res.getConfiguration().locale.getCountry())
           .setPlatform("android")
           .setSdkVersion(res.getString(R.string.perftracking__version))
+          .setOsVersion(Build.VERSION.RELEASE)
+          .setDevice(Build.MODEL)
           .build();
     } catch (PackageManager.NameNotFoundException e) {
       Log.d(TAG, "Error building request to config API", e);

--- a/Runtime/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigurationParam.java
+++ b/Runtime/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigurationParam.java
@@ -12,6 +12,8 @@ class ConfigurationParam {
   final String appVersion;
   final String sdkVersion;
   final String countryCode;
+  final String osVersion;
+  final String device;
 
   private ConfigurationParam(Builder builder) {
     platform = builder.platform;
@@ -19,6 +21,8 @@ class ConfigurationParam {
     appVersion = builder.appVersion;
     sdkVersion = builder.sdkVersion;
     countryCode = builder.countryCode;
+    osVersion = builder.osVersion;
+    device = builder.device;
   }
 
   static class Builder {
@@ -28,6 +32,8 @@ class ConfigurationParam {
     private String appVersion;
     private String sdkVersion;
     private String countryCode;
+    private String osVersion;
+    private String device;
 
     Builder setPlatform(String platform) {
       this.platform = platform;
@@ -54,6 +60,16 @@ class ConfigurationParam {
       return this;
     }
 
+    Builder setOsVersion(String osVersion) {
+      this.osVersion = osVersion;
+      return this;
+    }
+
+    Builder setDevice(String device) {
+      this.device = device;
+      return this;
+    }
+
     ConfigurationParam build() {
       if (platform == null) {
         throw new IllegalStateException("Platform cannot be null");
@@ -69,6 +85,12 @@ class ConfigurationParam {
       }
       if (countryCode == null) {
         throw new IllegalStateException("Country Code cannot be null");
+      }
+      if (osVersion == null) {
+        throw new IllegalStateException("OS Version cannot be null");
+      }
+      if (device == null) {
+        throw new IllegalStateException("Device cannot be null");
       }
       return new ConfigurationParam(this);
     }

--- a/Runtime/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigurationRequest.java
+++ b/Runtime/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigurationRequest.java
@@ -33,6 +33,8 @@ class ConfigurationRequest extends BaseRequest<ConfigurationResult> {
 
     setQueryParam("sdk", param.sdkVersion);
     setQueryParam("country", param.countryCode);
+    setQueryParam("osVersion", param.osVersion);
+    setQueryParam("device", param.device);
   }
 
   @Override

--- a/Runtime/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigurationParamBuilderSpec.java
+++ b/Runtime/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigurationParamBuilderSpec.java
@@ -47,4 +47,16 @@ public class ConfigurationParamBuilderSpec extends RobolectricUnitSpec {
     builder.setSdkVersion(null);
     builder.build();
   }
+
+  @Test(expected = IllegalStateException.class)
+  public void shouldEnforceOSVersion() {
+    builder.setOsVersion(null);
+    builder.build();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void shouldEnforceDevice() {
+    builder.setDevice(null);
+    builder.build();
+  }
 }

--- a/Runtime/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigurationRequestSpec.java
+++ b/Runtime/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigurationRequestSpec.java
@@ -10,11 +10,9 @@ import com.rakuten.tech.mobile.perf.runtime.TestData;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Mock;
 
 public class ConfigurationRequestSpec extends RobolectricUnitSpec {
 
-  @Mock ConfigurationRequest testMock;
   private ConfigurationParam.Builder builder;
 
   @Before public void initConfig() {
@@ -23,7 +21,9 @@ public class ConfigurationRequestSpec extends RobolectricUnitSpec {
         .setAppVersion("testVersion")
         .setSdkVersion("testSdkVersion")
         .setCountryCode("testCountryCode")
-        .setPlatform("testPlatform");
+        .setPlatform("testPlatform")
+        .setOsVersion("testOsVersion")
+        .setDevice("testDevice");
   }
 
   @Test public void shouldConstructWithNullableParameters() {
@@ -33,18 +33,17 @@ public class ConfigurationRequestSpec extends RobolectricUnitSpec {
   }
 
   @Test public void shouldBuildUrlWithDefaultUrlPrefix() {
-    ConfigurationRequest request = new ConfigurationRequest(null, "", builder.build(), null, null);
+    ConfigurationRequest request = new ConfigurationRequest(
+        null, "", builder.build(), null, null);
     assertThat(request.getUrl())
-        .isEqualTo(BuildConfig.DEFAULT_CONFIG_URL_PREFIX +
-            "/platform/testPlatform/app/testId/version/testVersion/?sdk=testSdkVersion&country=testCountryCode");
+        .startsWith(BuildConfig.DEFAULT_CONFIG_URL_PREFIX);
   }
 
   @Test public void shouldBuildUrlWithCustomDomain() {
     ConfigurationRequest request = new ConfigurationRequest("https://rakuten.co.jp", "", builder
         .build(), null, null);
     assertThat(request.getUrl())
-        .isEqualTo(
-            "https://rakuten.co.jp/platform/testPlatform/app/testId/version/testVersion/?sdk=testSdkVersion&country=testCountryCode");
+        .startsWith("https://rakuten.co.jp/");
   }
 
   @Test public void shouldBuildUrlWithCustomPrefix() {
@@ -52,8 +51,70 @@ public class ConfigurationRequestSpec extends RobolectricUnitSpec {
         new ConfigurationRequest("https://other.prefix.com/abc/xyz/v1",
             "", builder.build(), null, null);
     assertThat(request.getUrl())
-        .isEqualTo(
-            "https://other.prefix.com/abc/xyz/v1/platform/testPlatform/app/testId/version/testVersion/?sdk=testSdkVersion&country=testCountryCode");
+        .startsWith("https://other.prefix.com/abc/xyz/v1/");
+  }
+
+  @Test public void shouldBuildUrlWithPlatform() {
+    builder.setPlatform("testPlatform");
+
+    ConfigurationRequest request = new ConfigurationRequest(
+        null, "", builder.build(), null, null);
+    assertThat(request.getUrl())
+        .contains("/platform/testPlatform/");
+  }
+
+  @Test public void shouldBuildUrlWithAppId() {
+    builder.setAppId("testId");
+
+    ConfigurationRequest request =
+        new ConfigurationRequest(null, "", builder.build(), null, null);
+    assertThat(request.getUrl())
+        .contains("/app/testId/");
+  }
+
+  @Test public void shouldBuildUrlWithAppVersion() {
+    builder.setAppVersion("testVersion");
+
+    ConfigurationRequest request = new ConfigurationRequest(
+        null, "", builder.build(), null, null);
+    assertThat(request.getUrl())
+        .contains("/version/testVersion/");
+  }
+
+  @Test public void shouldBuildUrlWithSdkVersion() {
+    builder.setSdkVersion("testSdkVersion");
+
+    ConfigurationRequest request = new ConfigurationRequest(
+        null, "", builder.build(), null, null);
+    assertThat(request.getUrl())
+        .contains("sdk=testSdkVersion");
+  }
+
+  @Test public void shouldBuildUrlWithCountryCode() {
+    builder.setCountryCode("testCountryCode");
+
+    ConfigurationRequest request = new ConfigurationRequest(
+        null, "", builder.build(), null, null);
+    assertThat(request.getUrl())
+        .contains("country=testCountryCode");
+  }
+
+  @Test public void shouldBuildUrlWithOsVersion() {
+    builder.setOsVersion("testOsVersion");
+
+    ConfigurationRequest request = new ConfigurationRequest(
+        null, "", builder.build(), null, null);
+    assertThat(request.getUrl())
+        .contains("osVersion=testOsVersion");
+  }
+
+  @Test public void shouldBuildUrlWithDevice() {
+    builder.setDevice("test device name");
+
+    ConfigurationRequest request = new ConfigurationRequest(
+        null, "", builder.build(), null, null);
+    assertThat(request.getUrl())
+        .contains("device=test%20device%20name");
   }
 
   @Test public void shouldSetSubscriptionKeyHeader() {


### PR DESCRIPTION
# Description 
Sends `Build.VERSION.RELEASE` for the `osVersion` and `Build.MODEL` for the `device`.

## Links
APTT-323

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
