### PR TITLE
fix: Send the same country code to the config api and in the payload

### DIFF
--- a/Core/src/main/java/com/rakuten/tech/mobile/perf/core/EnvironmentInfo.java
+++ b/Core/src/main/java/com/rakuten/tech/mobile/perf/core/EnvironmentInfo.java
@@ -4,8 +4,6 @@ import android.app.Activity;
 import android.app.ActivityManager;
 import android.content.Context;
 import android.os.Build;
-import android.telephony.TelephonyManager;
-import java.util.Locale;
 import java.util.Observable;
 import java.util.Observer;
 
@@ -16,7 +14,7 @@ class EnvironmentInfo implements Observer {
   String network;
   final String osName;
   String osVersion;
-  private String country = null;
+  private String country;
   private String region = null;
   private float batteryLevel;
   private final long deviceTotalMemory;
@@ -39,23 +37,8 @@ class EnvironmentInfo implements Observer {
       this.deviceTotalMemory = -1L;
     }
 
-    TelephonyManager tm = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
-    if (tm != null) {
-      this.country = tm.getSimCountryIso();
-      this.network = tm.getNetworkOperatorName();
-    }
-
-    if (this.country == null || "".equals(this.country)) {
-      this.country = Locale.getDefault().getCountry();
-    }
-
-    if (this.country != null) {
-      this.country = this.country.toUpperCase();
-    }
-
-    if (this.network == null || "".equals(this.network)) {
-      this.network = "wifi";
-    }
+    this.network = TelephonyUtil.getNetwork(context);
+    this.country = TelephonyUtil.getCountryCode(context);
 
     if (locationObservable.getCachedValue() != null) {
       this.update(locationObservable, locationObservable.getCachedValue());

--- a/Core/src/main/java/com/rakuten/tech/mobile/perf/core/TelephonyUtil.java
+++ b/Core/src/main/java/com/rakuten/tech/mobile/perf/core/TelephonyUtil.java
@@ -1,0 +1,62 @@
+package com.rakuten.tech.mobile.perf.core;
+
+import android.content.Context;
+import android.telephony.TelephonyManager;
+import java.util.Locale;
+
+public final class TelephonyUtil {
+
+  private TelephonyUtil() {}
+
+  /**
+   * Returns the country code from the device SIM card if present,
+   * or the device's Locale country code if there is no SIM card.
+   *
+   * @param context application context
+   * @return country code
+   */
+  public static String getCountryCode(Context context) {
+    String country = null;
+
+    TelephonyManager tm = telephonyManager(context);
+    if (tm != null) {
+      country = tm.getSimCountryIso();
+    }
+
+    if (country == null || "".equals(country)) {
+      country = Locale.getDefault().getCountry();
+    }
+
+    if (country != null) {
+      country = country.toUpperCase();
+    }
+
+    return country;
+  }
+
+  /**
+   * Returns the network operator name for this device
+   * or "wifi" if there is no network name
+   *
+   * @param context application context
+   * @return network operator name
+   */
+  static String getNetwork(Context context) {
+    String network = null;
+
+    TelephonyManager tm = telephonyManager(context);
+    if (tm != null) {
+      network = tm.getNetworkOperatorName();
+    }
+
+    if (network == null || "".equals(network)) {
+      network = "wifi";
+    }
+
+    return network;
+  }
+
+  private static TelephonyManager telephonyManager(Context context) {
+    return (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
+  }
+}

--- a/Core/src/test/java/com/rakuten/tech/mobile/perf/core/EnvironmentInfoSpec.java
+++ b/Core/src/test/java/com/rakuten/tech/mobile/perf/core/EnvironmentInfoSpec.java
@@ -1,9 +1,9 @@
 package com.rakuten.tech.mobile.perf.core;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.when;
 
+import android.app.Activity;
 import android.app.ActivityManager;
 import android.content.Context;
 import android.os.Build;
@@ -13,56 +13,24 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 public class EnvironmentInfoSpec {
 
-  @Mock TelephonyManager tm;
-  @Mock ActivityManager am;
-  @Mock Context ctx;
+  @Mock TelephonyManager telephonyManager;
+  @Mock ActivityManager activityManager;
+  @Mock Context context;
   private CachingObservable<LocationData> location = new CachingObservable<LocationData>(null);
   private CachingObservable<Float> batteryinfo = new CachingObservable<Float>(null);
-  private final String simCountry = "TEST-SIM-COUNTRY";
-  private final String networkOperator = "test-network-operator";
-  private int invocationCount = 0;
 
   @Before public void initMocks() {
     MockitoAnnotations.initMocks(this);
-    when(tm.getSimCountryIso()).thenReturn(simCountry);
-    when(tm.getNetworkOperatorName()).thenReturn(networkOperator);
-    /*
-     * Because of the tricky setup of the SDK Context#getSystemService(String) will
-     * always be called with null. So we rely on the knowledge of internal implementation, i.e.
-     * the invocation order, to serve the correct stub. This is really shitty and for testing it
-     * would be better to directly inject the 2 system services into the constructor.
-     * In short: this a hacky workaround to make the stubbing work. This is likely to break when
-     * we refactor or evolve EnvironmentInfo
-     *
-     * Setting the tm or am to null (or any other reference) will make the context return null -
-     * be careful!
-     */
-    invocationCount = 0;
-    when(ctx.getSystemService(nullable(String.class)))
-        .thenAnswer(new Answer<Object>() {
-          @Override public Object answer(InvocationOnMock invocation) throws Throwable {
-            return invocationCount++ % 2 == 0 ? am : tm;
-          }
-        });
-  }
-
-
-  @Test
-  public void shouldReadCountryAndNetworkFromTelephonyManager() {
-    EnvironmentInfo info = new EnvironmentInfo(ctx, location, batteryinfo);
-    assertThat(info).isNotNull();
-    assertThat(info.getCountry()).isEqualTo(simCountry);
-    assertThat(info.network).isEqualTo(networkOperator);
+    when(context.getSystemService(Context.TELEPHONY_SERVICE)).thenReturn(telephonyManager);
+    when(context.getSystemService(Activity.ACTIVITY_SERVICE)).thenReturn(activityManager);
   }
 
   @Test
   public void shouldValidateDeviceInfo() {
-    EnvironmentInfo info = new EnvironmentInfo(ctx, location, batteryinfo);
+    EnvironmentInfo info = new EnvironmentInfo(context, location, batteryinfo);
     assertThat(info).isNotNull();
     assertThat(info.device).isEqualTo(Build.MODEL);
     assertThat(info.osName).isEqualTo("android");
@@ -70,10 +38,9 @@ public class EnvironmentInfoSpec {
   }
 
   @Test
-  public void shouldPointToDefaultCountryAndRegionWhenLocationIsNotUpdated() {
-    tm = null;
+  public void shouldPointToDefaultRegionWhenLocationIsNotUpdated() {
     Locale.setDefault(new Locale("testLanguage", "Test-Locale-Country", "testVariant"));
-    EnvironmentInfo info = new EnvironmentInfo(ctx, location, batteryinfo);
+    EnvironmentInfo info = new EnvironmentInfo(context, location, batteryinfo);
 
     assertThat(info.getRegion()).isEqualTo(null);
     assertThat(info.getCountry()).isEqualTo("TEST-LOCALE-COUNTRY");
@@ -82,7 +49,7 @@ public class EnvironmentInfoSpec {
   @Test
   public void shouldGetCountryAndRegionFromLocationUpdate() {
     LocationData locationData = new LocationData("IN", "Hyderabad");
-    EnvironmentInfo info = new EnvironmentInfo(ctx, location, batteryinfo);
+    EnvironmentInfo info = new EnvironmentInfo(context, location, batteryinfo);
 
     location.publish(locationData);
 
@@ -95,46 +62,9 @@ public class EnvironmentInfoSpec {
     LocationData cachedData = new LocationData("JP", "Tokyo");
     location.publish(cachedData);
 
-    EnvironmentInfo info = new EnvironmentInfo(ctx, location, batteryinfo);
+    EnvironmentInfo info = new EnvironmentInfo(context, location, batteryinfo);
 
     assertThat(info.getCountry()).isEqualTo(cachedData.country);
     assertThat(info.getRegion()).isEqualTo(cachedData.region);
   }
-
-  @Test
-  public void shouldFallbackToReadCountryFromLocaleIfTelephonyManagerIsNull() {
-    tm = null;
-    EnvironmentInfo info = new EnvironmentInfo(ctx, location, batteryinfo);
-    assertThat(info).isNotNull();
-    assertThat(info.getCountry()).isEqualToIgnoringCase(Locale.getDefault().getCountry());
-  }
-
-  @SuppressWarnings("RedundantStringConstructorCall")
-  @Test
-  public void shouldFallbackToReadCountryFromLocaleIfCountryIsEmpty() {
-    // prevent string literal from being "intern"ed so `== ""` is false in test setting, see
-    // http://stackoverflow.com/questions/27473457/in-java-why-does-string-string-evaluate-to-true-inside-a-method-as-opposed
-    when(tm.getSimCountryIso()).thenReturn(new String(""));
-    EnvironmentInfo info = new EnvironmentInfo(ctx, location, batteryinfo);
-    assertThat(info).isNotNull();
-    assertThat(info.getCountry()).isEqualToIgnoringCase(Locale.getDefault().getCountry());
-  }
-
-  @Test
-  public void shouldNormalizeCountryCodeToUppercase() {
-    TelephonyManager backupTm = tm;
-    tm = null;
-    Locale.setDefault(new Locale("testLanguage", "Test-Locale-Country", "testVariant"));
-    EnvironmentInfo info = new EnvironmentInfo(ctx, location, batteryinfo);
-    assertThat(info).isNotNull();
-    assertThat(info.getCountry()).isEqualTo("TEST-LOCALE-COUNTRY");
-
-    tm = backupTm;
-    when(tm.getSimCountryIso()).thenReturn("TEST-SIM-COUNTRY");
-
-    info = new EnvironmentInfo(ctx, location, batteryinfo);
-    assertThat(info).isNotNull();
-    assertThat(info.getCountry()).isEqualTo("TEST-SIM-COUNTRY");
-  }
-
 }

--- a/Core/src/test/java/com/rakuten/tech/mobile/perf/core/TelephonyUtilSpec.java
+++ b/Core/src/test/java/com/rakuten/tech/mobile/perf/core/TelephonyUtilSpec.java
@@ -1,0 +1,95 @@
+package com.rakuten.tech.mobile.perf.core;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.telephony.TelephonyManager;
+import java.util.Locale;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class TelephonyUtilSpec {
+
+  @Mock TelephonyManager telephonyManager;
+  @Mock Context context;
+
+  @Before
+  public void initMocks() {
+    MockitoAnnotations.initMocks(this);
+    when(context.getSystemService(Context.TELEPHONY_SERVICE)).thenReturn(telephonyManager);
+  }
+
+  @Test
+  public void shouldReadCountryFromTelephonyManager() {
+    when(telephonyManager.getSimCountryIso()).thenReturn("TEST-SIM-COUNTRY");
+
+    assertThat(TelephonyUtil.getCountryCode(context)).isEqualTo("TEST-SIM-COUNTRY");
+  }
+
+  @Test
+  public void shouldFallbackToReadCountryFromLocaleIfSimCountryIsEmpty() {
+    when(telephonyManager.getSimCountryIso()).thenReturn("");
+    Locale.setDefault(new Locale("testLanguage", "TEST-LOCALE-COUNTRY", "testVariant"));
+
+    assertThat(TelephonyUtil.getCountryCode(context)).isEqualTo("TEST-LOCALE-COUNTRY");
+  }
+
+  @Test
+  public void shouldFallbackToReadCountryFromLocaleIfSimCountryIsNull() {
+    when(telephonyManager.getSimCountryIso()).thenReturn(null);
+    Locale.setDefault(new Locale("testLanguage", "TEST-LOCALE-COUNTRY", "testVariant"));
+
+    assertThat(TelephonyUtil.getCountryCode(context)).isEqualTo("TEST-LOCALE-COUNTRY");
+  }
+
+  @Test
+  public void shouldFallbackToReadCountryFromLocaleIfTelephonyManagerIsNull() {
+    when(context.getSystemService(Context.TELEPHONY_SERVICE)).thenReturn(null);
+    Locale.setDefault(new Locale("testLanguage", "TEST-LOCALE-COUNTRY", "testVariant"));
+
+    assertThat(TelephonyUtil.getCountryCode(context)).isEqualTo("TEST-LOCALE-COUNTRY");
+  }
+
+  @Test
+  public void shouldNormalizeCountryCodeToUppercase() {
+    when(telephonyManager.getSimCountryIso()).thenReturn("");
+    Locale.setDefault(new Locale("testLanguage", "Test-Locale-Country", "testVariant"));
+
+    assertThat(TelephonyUtil.getCountryCode(context)).isEqualTo("TEST-LOCALE-COUNTRY");
+
+    when(telephonyManager.getSimCountryIso()).thenReturn("test-sim-country");
+
+    assertThat(TelephonyUtil.getCountryCode(context)).isEqualTo("TEST-SIM-COUNTRY");
+  }
+
+  @Test
+  public void shouldReadNetworkFromTelephonyManager() {
+    when(telephonyManager.getNetworkOperatorName()).thenReturn("test-network-operator");
+
+    assertThat(TelephonyUtil.getNetwork(context)).isEqualTo("test-network-operator");
+  }
+
+  @Test
+  public void shouldFallbackToDefaultWhenTelphonyMangerIsNull() {
+    when(context.getSystemService(Context.TELEPHONY_SERVICE)).thenReturn(null);
+
+    assertThat(TelephonyUtil.getNetwork(context)).isEqualTo("wifi");
+  }
+
+  @Test
+  public void shouldFallbackToDefaultWhenNetworkNameIsEmpty() {
+    when(telephonyManager.getNetworkOperatorName()).thenReturn("");
+
+    assertThat(TelephonyUtil.getNetwork(context)).isEqualTo("wifi");
+  }
+
+  @Test
+  public void shouldFallbackToDefaultWhenNetworkNameIsNull() {
+    when(telephonyManager.getNetworkOperatorName()).thenReturn(null);
+
+    assertThat(TelephonyUtil.getNetwork(context)).isEqualTo("wifi");
+  }
+}

--- a/Core/src/test/java/com/rakuten/tech/mobile/perf/core/TrackerImplSpec.java
+++ b/Core/src/test/java/com/rakuten/tech/mobile/perf/core/TrackerImplSpec.java
@@ -130,7 +130,7 @@ public class TrackerImplSpec {
       tracker.startMetric("some metric");
       Thread.sleep(100);
       tracker.prolongMetric();
-      assertThat(metric.get().endTime).isGreaterThan(beforeStart + 100);
+      assertThat(metric.get().endTime).isGreaterThanOrEqualTo(beforeStart + 100);
     }
 
     @Test public void shouldNotUpdateEndTimeOnEndMetric() throws InterruptedException {

--- a/Runtime/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigStore.java
+++ b/Runtime/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigStore.java
@@ -16,6 +16,7 @@ import com.android.volley.Response;
 import com.android.volley.VolleyError;
 import com.google.gson.Gson;
 import com.rakuten.tech.mobile.perf.R;
+import com.rakuten.tech.mobile.perf.core.TelephonyUtil;
 import com.rakuten.tech.mobile.perf.core.Tracker;
 import java.util.Random;
 
@@ -54,9 +55,11 @@ class ConfigStore extends Store<ConfigurationResult> {
   @NonNull private final SharedPreferences prefs;
   @NonNull private final Resources res;
   @NonNull private final Handler handler;
+  @NonNull private final Context context;
 
   ConfigStore(@NonNull Context context, @NonNull RequestQueue requestQueue,
       @NonNull String relayAppId, @Nullable String subscriptionKey, @Nullable String urlPrefix) {
+    this.context = context;
     this.packageManager = context.getPackageManager();
     this.packageName = context.getPackageName();
     this.appId = relayAppId;
@@ -87,7 +90,7 @@ class ConfigStore extends Store<ConfigurationResult> {
       param = new ConfigurationParam.Builder()
           .setAppId(appId)
           .setAppVersion(packageManager.getPackageInfo(packageName, 0).versionName)
-          .setCountryCode(res.getConfiguration().locale.getCountry())
+          .setCountryCode(TelephonyUtil.getCountryCode(context))
           .setPlatform("android")
           .setSdkVersion(res.getString(R.string.perftracking__version))
           .setOsVersion(Build.VERSION.RELEASE)

--- a/Stubs/src/main/java/android/app/Activity.java
+++ b/Stubs/src/main/java/android/app/Activity.java
@@ -9,7 +9,7 @@ import android.view.View;
 
 public class Activity {
 
-  public static final String ACTIVITY_SERVICE = null;
+  public static final String ACTIVITY_SERVICE = "activity";
 
   public Intent getIntent() {
     return null;

--- a/Stubs/src/main/java/android/content/Context.java
+++ b/Stubs/src/main/java/android/content/Context.java
@@ -2,7 +2,7 @@ package android.content;
 
 public abstract class Context {
 
-  public static final String TELEPHONY_SERVICE = null;
+  public static final String TELEPHONY_SERVICE = "telephony";
 
   public void startActivity(Intent intent) {
   }


### PR DESCRIPTION
# Description 
Previously, the config API was always sent the country code found from the device locale, whereas the payload was sending the SIM card's country code or the locale if no SIM card is found. This commit changes the ConfigStore to use the same method for retrieving the country code as the payload does.

## Links
APTT-374

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
