### PR TITLE
test: Fix threading issues in SenderThreadSpec

### DIFF
--- a/Core/build.gradle
+++ b/Core/build.gradle
@@ -17,6 +17,7 @@ dependencies {
   // use mockito-inline instead of mockito-core to allow mocking final classes
   // see http://static.javadoc.io/org.mockito/mockito-core/2.7.22/org/mockito/Mockito.html#39
   testImplementation "org.mockito:mockito-inline:2.7.22"
+  testImplementation 'org.awaitility:awaitility:3.1.0'
 }
 
 // copy resources to classes dir so they are available on the test classpath


### PR DESCRIPTION
# Description 
Fixes #31.

Replaced usages of Thread#sleep with Awaitility or Mockito#timeout. Additionally, fixed an issue where the populateBufferRunnable was not terminated after being used, so it would cause NullPointerException sometimes. Previously, some of these unit tests were failing occasionally on CI.

The only other place where `Thread#sleep` is used is in `TrackerImplSpec`, however these appear to be valid uses because it's being used to test metric start and end times.

## Links
#31 

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
