### PR TITLE
test: Increase verify timeouts for SenderThreadSpec

### DIFF
--- a/Core/src/test/java/com/rakuten/tech/mobile/perf/core/SenderThreadSpec.java
+++ b/Core/src/test/java/com/rakuten/tech/mobile/perf/core/SenderThreadSpec.java
@@ -72,7 +72,7 @@ public class SenderThreadSpec {
       });
       startSenderThread(senderThread);
 
-      verify(sender, timeout(50).atLeast(1)).send(anyInt());
+      verify(sender, timeout(100).atLeast(1)).send(anyInt());
 
       terminateSenderThread(senderThread);
 
@@ -102,7 +102,7 @@ public class SenderThreadSpec {
       verify(sender, timeout(100).atLeast(1)).send(anyInt());
       clearInvocations(sender);
 
-      verify(sender, timeout(25).atLeast(1)).send(anyInt());
+      verify(sender, timeout(100).atLeast(1)).send(anyInt());
     }
   }
 


### PR DESCRIPTION
# Description 
The timeout for some tests was too low so it was failing on some slower machines. Note: one test will be invalid if the timeout is increased too high (`MockedSender#shouldResetBackOffAfterSuccess`) which is why it was set to `25` previously. However, I red-tested it with `100` and it is still valid.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
