### PR TITLE
Fix corner case

### DIFF
--- a/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/RuntimeContentProvider.java
+++ b/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/RuntimeContentProvider.java
@@ -88,7 +88,7 @@ public class RuntimeContentProvider extends ContentProvider {
     boolean appDebuggable = Util.isAppDebuggable(context);
     double enablePercent = lastConfig.getEnablePercent();
     double randomNumber = new Random(System.currentTimeMillis()).nextDouble() * 100.0;
-    boolean enableTracking = (randomNumber <= enablePercent);
+    boolean enableTracking = randomNumber < enablePercent;
     if (appDebuggable || enableTracking) {
       config = new Config();
       config.app = packageName;


### PR DESCRIPTION
# Description 
Performance tracking should not be enabled when enablePercent and randomNumber are zero

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
