### PR TITLE
Blacklist for Analytics Broadcast

### DIFF
--- a/performance-tracking-core/src/main/java/com/rakuten/tech/mobile/perf/core/Analytics.java
+++ b/performance-tracking-core/src/main/java/com/rakuten/tech/mobile/perf/core/Analytics.java
@@ -10,7 +10,20 @@ public abstract class Analytics {
   @SuppressWarnings("WeakerAccess")
   public abstract void sendEvent(String name, Map<String, ?> data);
 
+  /**
+   * Subclasses can hook into this method to filter url measurements without knowing internals.
+   *
+   * @param url string url
+   * @return true if url blacklisted (events will be skipped), false otherwise
+   */
+  protected boolean isUrlBlacklisted(String url) {
+    return false;
+  };
+
   void sendUrlMeasurement(Measurement m, String cdnHeader, long contentLength) {
+    if(isUrlBlacklisted((String) m.a)) {
+      return;
+    }
     Map<String, Object> event =  new HashMap<>();
 
     Map<String, Object> entry =  new HashMap<>();

--- a/performance-tracking/build.gradle
+++ b/performance-tracking/build.gradle
@@ -46,6 +46,9 @@ dependencies {
   implementation "com.google.code.gson:gson:${CONFIG.versions.thirdParty.gson}"
   implementation "com.android.volley:volley:${CONFIG.versions.android.libraries.volley}"
 
+  implementation 'com.rakuten.tech.mobile:manifest-config-annotations:0.1.0'
+  annotationProcessor   'com.rakuten.tech.mobile:manifest-config-processor:0.1.0'
+
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.assertj:assertj-core:3.11.1'
   testImplementation 'org.skyscreamer:jsonassert:1.5.0'

--- a/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/App.java
+++ b/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/App.java
@@ -1,0 +1,23 @@
+package com.rakuten.tech.mobile.perf.runtime.internal;
+
+import com.rakuten.tech.mobile.manifestconfig.annotations.ManifestConfig;
+import com.rakuten.tech.mobile.manifestconfig.annotations.MetaData;
+import com.rakuten.tech.mobile.perf.BuildConfig;
+
+@ManifestConfig
+public interface App {
+  @MetaData(key = "com.rakuten.tech.mobile.analytics.RATEndpoint", value = "https://rat.rakuten.co.jp/")
+  String ratEndPoint();
+
+  @MetaData(key = "com.rakuten.tech.mobile.perf.ConfigurationUrlPrefix", value = BuildConfig.DEFAULT_CONFIG_URL_PREFIX)
+  String configUrlPrefix();
+
+  @MetaData(key = "com.rakuten.tech.mobile.perf.LocationUrlPrefix", value = BuildConfig.DEFAULT_LOCATION_URL_PREFIX)
+  String locationUrlPrefix();
+
+  @MetaData(key = "com.rakuten.tech.mobile.relay.AppId")
+  String appId();
+
+  @MetaData(key = "com.rakuten.tech.mobile.relay.SubscriptionKey")
+  String appKey();
+}

--- a/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigStore.java
+++ b/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigStore.java
@@ -9,6 +9,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 import android.util.Log;
 import com.android.volley.RequestQueue;
 import com.android.volley.Response;
@@ -49,7 +50,7 @@ class ConfigStore extends Store<ConfigurationResult> {
   private static final int TIME_INTERVAL = 60 * 60 * 1000; // 1 HOUR in milli seconds
 
   @Nullable private final String subscriptionKey;
-  @Nullable private final String urlPrefix;
+  @NonNull private final String urlPrefix;
   @NonNull private final String appId;
   @NonNull private final RequestQueue requestQueue;
   @NonNull private final String packageName;
@@ -64,7 +65,7 @@ class ConfigStore extends Store<ConfigurationResult> {
       @NonNull RequestQueue requestQueue,
       @NonNull String relayAppId,
       @Nullable String subscriptionKey,
-      @Nullable String urlPrefix) {
+      @NonNull String urlPrefix) {
     this.context = context;
     this.packageManager = context.getPackageManager();
     this.packageName = context.getPackageName();
@@ -108,12 +109,6 @@ class ConfigStore extends Store<ConfigurationResult> {
       Log.d(TAG, "Error building request to config API", e);
     }
 
-    if (subscriptionKey == null) {
-      Log.d(
-          TAG,
-          "Cannot read metadata `com.rakuten.tech.mobile.perf.SubscriptionKey` from"
-              + "manifest, automated performance tracking will not work.");
-    }
     if (param != null) {
       new ConfigurationRequest(
               urlPrefix,

--- a/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigurationRequest.java
+++ b/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigurationRequest.java
@@ -1,6 +1,7 @@
 package com.rakuten.tech.mobile.perf.runtime.internal;
 
 import android.net.Uri;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
 import com.android.volley.Response;
@@ -10,19 +11,16 @@ import com.rakuten.tech.mobile.perf.BuildConfig;
 /** ConfigurationRequest */
 class ConfigurationRequest extends BaseRequest<ConfigurationResult> {
 
-  private static final String DEFAULT_URL_PREFIX = BuildConfig.DEFAULT_CONFIG_URL_PREFIX;
-
   ConfigurationRequest(
-      @Nullable String urlPrefix,
-      String subscriptionKey,
-      ConfigurationParam param,
+      @NonNull String urlPrefix,
+      @Nullable String subscriptionKey,
+      @NonNull ConfigurationParam param,
       @Nullable Response.Listener<ConfigurationResult> listener,
       @Nullable Response.ErrorListener errorListener) {
     super(listener, errorListener);
     setMethod(Method.GET);
     setHeader("Ocp-Apim-Subscription-Key", subscriptionKey);
-    String prefix = urlPrefix != null ? urlPrefix : DEFAULT_URL_PREFIX;
-    Uri uri = Uri.parse(prefix);
+    Uri uri = Uri.parse(urlPrefix);
     uri =
         uri.buildUpon()
             .appendPath("platform")

--- a/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/GeoLocationRequest.java
+++ b/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/GeoLocationRequest.java
@@ -1,5 +1,6 @@
 package com.rakuten.tech.mobile.perf.runtime.internal;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.android.volley.Response;
 import com.android.volley.VolleyError;
@@ -10,17 +11,15 @@ import com.rakuten.tech.mobile.perf.BuildConfig;
 /** GeoLocationRequest */
 class GeoLocationRequest extends BaseRequest<GeoLocationResult> {
 
-  private static final String DEFAULT_URL_PREFIX = BuildConfig.DEFAULT_LOCATION_URL_PREFIX;
-
   GeoLocationRequest(
-      @Nullable String urlPrefix,
-      String subscriptionKey,
+      @NonNull String urlPrefix,
+      @Nullable String subscriptionKey,
       @Nullable Response.Listener<GeoLocationResult> listener,
       @Nullable Response.ErrorListener errorListener) {
     super(listener, errorListener);
     setMethod(Method.GET);
     setHeader("Ocp-Apim-Subscription-Key", subscriptionKey);
-    setUrl(urlPrefix != null ? urlPrefix : DEFAULT_URL_PREFIX);
+    setUrl(urlPrefix);
   }
 
   @Override

--- a/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/LocationStore.java
+++ b/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/LocationStore.java
@@ -44,7 +44,7 @@ class LocationStore extends Store<LocationData> {
   private static final int TIME_INTERVAL = 60 * 60 * 1000; // 1 HOUR in milli seconds
 
   @Nullable private final String subscriptionKey;
-  @Nullable private final String urlPrefix;
+  @NonNull private final String urlPrefix;
   @NonNull private final RequestQueue requestQueue;
   @NonNull private final SharedPreferences prefs;
   @NonNull private final Handler handler;
@@ -53,7 +53,7 @@ class LocationStore extends Store<LocationData> {
       @NonNull Context context,
       @NonNull RequestQueue requestQueue,
       @Nullable String subscriptionKey,
-      @Nullable String urlPrefix) {
+      @NonNull String urlPrefix) {
     this.prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
     this.requestQueue = requestQueue;
     this.subscriptionKey = subscriptionKey;

--- a/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/Util.java
+++ b/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/Util.java
@@ -7,9 +7,7 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.Signature;
-import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.annotation.RestrictTo;
 import android.support.annotation.VisibleForTesting;
 import java.io.ByteArrayInputStream;
@@ -21,54 +19,7 @@ import java.security.cert.X509Certificate;
 @VisibleForTesting(otherwise = PACKAGE_PRIVATE)
 public final class Util {
 
-  private static final String SUBSCRIPTION_META_KEY =
-      "com.rakuten.tech.mobile.relay.SubscriptionKey";
-  private static final String RELAY_APP_ID = "com.rakuten.tech.mobile.relay.AppId";
-
   private Util() {}
-
-  /**
-   * Extract the (shared) relay subscription key from the app's manifest. The key is expected as
-   * shown below:
-   *
-   * <p>```xml <manifest> <application> <meta-data
-   * android:name="com.rakuten.tech.mobile.relay.SubscriptionKey" android:value="subscriptionKey" />
-   * </application> </manifest> ```
-   *
-   * @param context application context
-   * @return subscription key if present, null otherwise
-   */
-  /* default */ static @Nullable String getSubscriptionKey(@NonNull final Context context) {
-    return getMeta(context, SUBSCRIPTION_META_KEY);
-  }
-
-  /**
-   * Extract the relay app id from the app's manifest. The appId is expected as shown below:
-   *
-   * <p>```xml <manifest> <application> <meta-data
-   * android:name="com.rakuten.tech.mobile.relay.AppId" android:value="appId" /> </application>
-   * </manifest> ```
-   *
-   * @param context application context
-   * @return relay app id if present, null otherwise
-   */
-  /* default */ static @Nullable String getRelayAppId(@NonNull final Context context) {
-    return getMeta(context, RELAY_APP_ID);
-  }
-
-  /* default */ static @Nullable String getMeta(
-      @NonNull final Context context, @NonNull final String key) {
-    try {
-      Bundle metaData =
-          context
-              .getPackageManager()
-              .getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA)
-              .metaData;
-      return metaData != null ? metaData.getString(key) : null;
-    } catch (PackageManager.NameNotFoundException e) {
-      return null;
-    }
-  }
 
   /**
    * Check if the application is debuggable.

--- a/performance-tracking/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/AnalyticsBroadcastSpec.java
+++ b/performance-tracking/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/AnalyticsBroadcastSpec.java
@@ -86,6 +86,18 @@ public class AnalyticsBroadcastSpec extends RobolectricUnitSpec {
     assertThat((Map<String, Object>) intent.getSerializableExtra("event-data")).containsAllEntriesOf(map);
   }
 
+  @Test public void shouldBlacklistEventsByDomain() {
+    AnalyticsBroadcaster analytics = new AnalyticsBroadcaster(ctx, "https://rat.rakuten.co.jp/");
+
+    assertThat(analytics.isUrlBlacklisted("http://rat.rakuten.co.jp")).isTrue(); // same schema & host
+    assertThat(analytics.isUrlBlacklisted("https://rat.rakuten.co.jp")).isTrue(); // different schema & same host
+    assertThat(analytics.isUrlBlacklisted("http://rat.rakuten.co.jp/some/path")).isTrue(); // with url path
+    assertThat(analytics.isUrlBlacklisted("")).isFalse(); // invalid url
+    assertThat(analytics.isUrlBlacklisted("http://rakuten.co.jp")).isFalse(); // different domain
+    assertThat(analytics.isUrlBlacklisted("http://sub.rat.rakuten.co.jp")).isFalse(); // subdomain
+    assertThat(analytics.isUrlBlacklisted("rat.rakuten.co.jp")).isFalse(); // missing schema
+  }
+
   private Intent captureIntent() {
     ArgumentCaptor<Intent> captor = ArgumentCaptor.forClass(Intent.class);
     verify(receiver, atLeastOnce()).onReceive(any(Context.class), captor.capture());

--- a/performance-tracking/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigStoreSpec.java
+++ b/performance-tracking/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigStoreSpec.java
@@ -61,19 +61,19 @@ public class ConfigStoreSpec extends RobolectricUnitSpec {
 
   @Test(expected = IllegalStateException.class)
   public void shouldFailToCreateConfigStoreOnNullAppId() {
-    configStore = new ConfigStore(context, queue, null, "", null);
+    configStore = new ConfigStore(context, queue, null, "", "");
   }
 
   @Test(expected = IllegalStateException.class)
   public void shouldFailToCreateConfigStoreOnEmptyAppId() {
-    configStore = new ConfigStore(context, queue, "", "", null);
+    configStore = new ConfigStore(context, queue, "", "", "");
   }
 
   @Test
   public void shouldRequestConfigOnEmptyCache() throws JSONException {
     queue.rule().whenClass(ConfigurationRequest.class).returnNetworkResponse(200, config.content);
 
-    configStore = new ConfigStore(context, queue, appId, "", null);
+    configStore = new ConfigStore(context, queue, appId, "", "");
 
     queue.verify();
   }
@@ -82,7 +82,7 @@ public class ConfigStoreSpec extends RobolectricUnitSpec {
   public void shouldCacheConfigOnEmptyCache() throws JSONException {
     queue.rule().whenClass(ConfigurationRequest.class).returnNetworkResponse(200, config.content);
 
-    configStore = new ConfigStore(context, queue, appId, "", null);
+    configStore = new ConfigStore(context, queue, appId, "", "");
 
     ConfigurationResult cachedResponse = configStore.getObservable().getCachedValue();
     JSONAssert.assertEquals(config.content, new Gson().toJson(cachedResponse), true);
@@ -93,7 +93,7 @@ public class ConfigStoreSpec extends RobolectricUnitSpec {
     prefs.edit().putString("config_key", config.content).apply();
 
     // Cached config available
-    configStore = new ConfigStore(context, queue, appId, "", null);
+    configStore = new ConfigStore(context, queue, appId, "", "");
 
     ConfigurationResult cachedResponse = configStore.getObservable().getCachedValue();
     JSONAssert.assertEquals(config.content, new Gson().toJson(cachedResponse), true);
@@ -102,7 +102,7 @@ public class ConfigStoreSpec extends RobolectricUnitSpec {
   @Test
   public void shouldUseNullConfigOnEmptyCacheOnInstanceCreation() throws JSONException {
     // EmptyCache
-    configStore = new ConfigStore(context, queue, appId, "", null);
+    configStore = new ConfigStore(context, queue, appId, "", "");
 
     ConfigurationResult storeValue = configStore.getObservable().getCachedValue();
     assertThat(storeValue).isEqualTo(null);
@@ -115,14 +115,14 @@ public class ConfigStoreSpec extends RobolectricUnitSpec {
         .whenClass(ConfigurationRequest.class)
         .returnError(new VolleyError(new Throwable()));
 
-    configStore = new ConfigStore(context, queue, appId, "", null);
+    configStore = new ConfigStore(context, queue, appId, "", "");
 
     queue.verify();
   }
 
   @Test
   public void shouldDoWhatWhenSubscriptionKeyIsMissing() {
-    configStore = new ConfigStore(context, queue, appId, null, null);
+    configStore = new ConfigStore(context, queue, appId, null, "");
   }
 
   @Test
@@ -133,7 +133,7 @@ public class ConfigStoreSpec extends RobolectricUnitSpec {
         .when(packageManager)
         .getPackageInfo(anyString(), anyInt());
 
-    configStore = new ConfigStore(context, queue, appId, null, null);
+    configStore = new ConfigStore(context, queue, appId, null, "");
 
     ConfigurationResult cachedResponse = configStore.getObservable().getCachedValue();
     JSONAssert.assertEquals(config.content, new Gson().toJson(cachedResponse), true);

--- a/performance-tracking/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigurationRequestSpec.java
+++ b/performance-tracking/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigurationRequestSpec.java
@@ -30,15 +30,9 @@ public class ConfigurationRequestSpec extends RobolectricUnitSpec {
 
   @Test
   public void shouldConstructWithNullableParameters() {
-    ConfigurationRequest request = new ConfigurationRequest(null, "", builder.build(), null, null);
+    ConfigurationRequest request = new ConfigurationRequest("", "", builder.build(), null, null);
     assertThat(request).isNotNull();
     assertThat(request.getMethod()).isEqualTo(Request.Method.GET);
-  }
-
-  @Test
-  public void shouldBuildUrlWithDefaultUrlPrefix() {
-    ConfigurationRequest request = new ConfigurationRequest(null, "", builder.build(), null, null);
-    assertThat(request.getUrl()).startsWith(BuildConfig.DEFAULT_CONFIG_URL_PREFIX);
   }
 
   @Test
@@ -60,7 +54,7 @@ public class ConfigurationRequestSpec extends RobolectricUnitSpec {
   public void shouldBuildUrlWithPlatform() {
     builder.setPlatform("testPlatform");
 
-    ConfigurationRequest request = new ConfigurationRequest(null, "", builder.build(), null, null);
+    ConfigurationRequest request = new ConfigurationRequest("", "", builder.build(), null, null);
     assertThat(request.getUrl()).contains("/platform/testPlatform/");
   }
 
@@ -68,7 +62,7 @@ public class ConfigurationRequestSpec extends RobolectricUnitSpec {
   public void shouldBuildUrlWithAppId() {
     builder.setAppId("testId");
 
-    ConfigurationRequest request = new ConfigurationRequest(null, "", builder.build(), null, null);
+    ConfigurationRequest request = new ConfigurationRequest("", "", builder.build(), null, null);
     assertThat(request.getUrl()).contains("/app/testId/");
   }
 
@@ -76,7 +70,7 @@ public class ConfigurationRequestSpec extends RobolectricUnitSpec {
   public void shouldBuildUrlWithAppVersion() {
     builder.setAppVersion("testVersion");
 
-    ConfigurationRequest request = new ConfigurationRequest(null, "", builder.build(), null, null);
+    ConfigurationRequest request = new ConfigurationRequest("", "", builder.build(), null, null);
     assertThat(request.getUrl()).contains("/version/testVersion/");
   }
 
@@ -84,7 +78,7 @@ public class ConfigurationRequestSpec extends RobolectricUnitSpec {
   public void shouldBuildUrlWithSdkVersion() {
     builder.setSdkVersion("testSdkVersion");
 
-    ConfigurationRequest request = new ConfigurationRequest(null, "", builder.build(), null, null);
+    ConfigurationRequest request = new ConfigurationRequest("", "", builder.build(), null, null);
     assertThat(request.getUrl()).contains("sdk=testSdkVersion");
   }
 
@@ -92,7 +86,7 @@ public class ConfigurationRequestSpec extends RobolectricUnitSpec {
   public void shouldBuildUrlWithCountryCode() {
     builder.setCountryCode("testCountryCode");
 
-    ConfigurationRequest request = new ConfigurationRequest(null, "", builder.build(), null, null);
+    ConfigurationRequest request = new ConfigurationRequest("", "", builder.build(), null, null);
     assertThat(request.getUrl()).contains("country=testCountryCode");
   }
 
@@ -100,7 +94,7 @@ public class ConfigurationRequestSpec extends RobolectricUnitSpec {
   public void shouldBuildUrlWithOsVersion() {
     builder.setOsVersion("testOsVersion");
 
-    ConfigurationRequest request = new ConfigurationRequest(null, "", builder.build(), null, null);
+    ConfigurationRequest request = new ConfigurationRequest("", "", builder.build(), null, null);
     assertThat(request.getUrl()).contains("osVersion=testOsVersion");
   }
 
@@ -108,7 +102,7 @@ public class ConfigurationRequestSpec extends RobolectricUnitSpec {
   public void shouldBuildUrlWithDevice() {
     builder.setDevice("test device name");
 
-    ConfigurationRequest request = new ConfigurationRequest(null, "", builder.build(), null, null);
+    ConfigurationRequest request = new ConfigurationRequest("", "", builder.build(), null, null);
     assertThat(request.getUrl()).contains("device=test%20device%20name");
   }
 
@@ -116,7 +110,7 @@ public class ConfigurationRequestSpec extends RobolectricUnitSpec {
   public void shouldSetSubscriptionKeyHeader() {
     String testKey = "testKey";
     ConfigurationRequest request =
-        new ConfigurationRequest(null, testKey, builder.build(), null, null);
+        new ConfigurationRequest("", testKey, builder.build(), null, null);
     assertThat(request.getHeaders()).has(keyValue("Ocp-Apim-Subscription-Key", testKey));
   }
 
@@ -124,7 +118,7 @@ public class ConfigurationRequestSpec extends RobolectricUnitSpec {
 
   @Test
   public void shouldParseResponse() {
-    ConfigurationRequest request = new ConfigurationRequest(null, "", builder.build(), null, null);
+    ConfigurationRequest request = new ConfigurationRequest("", "", builder.build(), null, null);
     ConfigurationResult response = request.parseResponse(data.content);
     assertThat(response).isNotNull();
     assertThat(response.getSendUrl())
@@ -148,7 +142,7 @@ public class ConfigurationRequestSpec extends RobolectricUnitSpec {
 
   @Test
   public void shouldNotFailOnInvalidResponseString() {
-    ConfigurationRequest request = new ConfigurationRequest(null, "", builder.build(), null, null);
+    ConfigurationRequest request = new ConfigurationRequest("", "", builder.build(), null, null);
     ConfigurationResult result = request.parseResponse("some invalid json [[[[}}}");
     assertThat(result).isNull();
     // no exception

--- a/performance-tracking/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/GeoLocationRequestSpec.java
+++ b/performance-tracking/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/GeoLocationRequestSpec.java
@@ -15,15 +15,9 @@ public class GeoLocationRequestSpec extends RobolectricUnitSpec {
 
   @Test
   public void shouldConstructWithNullableParameters() {
-    GeoLocationRequest request = new GeoLocationRequest(null, "", null, null);
+    GeoLocationRequest request = new GeoLocationRequest("", "", null, null);
     assertThat(request).isNotNull();
     assertThat(request.getMethod()).isEqualTo(Request.Method.GET);
-  }
-
-  @Test
-  public void shouldBuildUrlWithDefaultUrlPrefix() {
-    GeoLocationRequest request = new GeoLocationRequest(null, "", null, null);
-    assertThat(request.getUrl()).isEqualTo(BuildConfig.DEFAULT_LOCATION_URL_PREFIX);
   }
 
   @Test
@@ -36,7 +30,7 @@ public class GeoLocationRequestSpec extends RobolectricUnitSpec {
   @Test
   public void shouldSetSubscriptionKeyHeader() {
     String testKey = "testKey";
-    GeoLocationRequest request = new GeoLocationRequest(null, testKey, null, null);
+    GeoLocationRequest request = new GeoLocationRequest("", testKey, null, null);
     assertThat(request.getHeaders()).has(keyValue("Ocp-Apim-Subscription-Key", testKey));
   }
 
@@ -44,7 +38,7 @@ public class GeoLocationRequestSpec extends RobolectricUnitSpec {
 
   @Test
   public void shouldParseResponse() throws VolleyError {
-    GeoLocationRequest request = new GeoLocationRequest(null, "", null, null);
+    GeoLocationRequest request = new GeoLocationRequest("", "", null, null);
     GeoLocationResult response = request.parseResponse(data.content);
     assertThat(response).isNotNull();
     assertThat(response.getRegionName().equals("Tokyo"));
@@ -52,7 +46,7 @@ public class GeoLocationRequestSpec extends RobolectricUnitSpec {
 
   @Test(expected = VolleyError.class)
   public void shouldNotFailOnInvalidResponseString() throws VolleyError {
-    GeoLocationRequest request = new GeoLocationRequest(null, "", null, null);
+    GeoLocationRequest request = new GeoLocationRequest("", "", null, null);
     GeoLocationResult result = request.parseResponse("some invalid json [[[[}}}");
     assertThat(result).isNull();
   }

--- a/performance-tracking/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/LocationStoreSpec.java
+++ b/performance-tracking/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/LocationStoreSpec.java
@@ -57,7 +57,7 @@ public class LocationStoreSpec extends RobolectricUnitSpec {
   public void shouldRequestLocationOnEmptyCache() throws JSONException {
     queue.rule().whenClass(GeoLocationRequest.class).returnNetworkResponse(200, location.content);
 
-    locationStore = new LocationStore(context, queue, "", null);
+    locationStore = new LocationStore(context, queue, "", "");
 
     queue.verify();
   }
@@ -67,7 +67,7 @@ public class LocationStoreSpec extends RobolectricUnitSpec {
     LocationData expectedValue = new LocationData("JP", "Tokyo");
     queue.rule().whenClass(GeoLocationRequest.class).returnNetworkResponse(200, location.content);
 
-    locationStore = new LocationStore(context, queue, "", null);
+    locationStore = new LocationStore(context, queue, "", "");
 
     LocationData storeValue = locationStore.getObservable().getCachedValue();
     assertThat(storeValue.country).isEqualTo(expectedValue.country);
@@ -79,7 +79,7 @@ public class LocationStoreSpec extends RobolectricUnitSpec {
     LocationData prefsValue = new LocationData("JP", "Tokyo");
     prefs.edit().putString("location_key", new Gson().toJson(prefsValue)).apply();
 
-    locationStore = new LocationStore(context, queue, "", null);
+    locationStore = new LocationStore(context, queue, "", "");
 
     LocationData storeValue = locationStore.getObservable().getCachedValue();
     assertThat(storeValue.country).isEqualTo(prefsValue.country);
@@ -88,7 +88,7 @@ public class LocationStoreSpec extends RobolectricUnitSpec {
 
   @Test
   public void shouldUseNullLocationOnEmptyCacheForInstanceCreation() throws JSONException {
-    locationStore = new LocationStore(context, queue, "", null);
+    locationStore = new LocationStore(context, queue, "", "");
 
     LocationData storeValue = locationStore.getObservable().getCachedValue();
     assertThat(storeValue).isEqualTo(null);
@@ -98,13 +98,13 @@ public class LocationStoreSpec extends RobolectricUnitSpec {
   public void shouldNotFailOnFailedLocationRequest() {
     queue.rule().whenClass(GeoLocationRequest.class).returnError(new VolleyError(new Throwable()));
 
-    locationStore = new LocationStore(context, queue, "", null);
+    locationStore = new LocationStore(context, queue, "", "");
 
     queue.verify();
   }
 
   @Test
   public void shouldDoWhatWhenSubscriptionKeyIsMissing() {
-    locationStore = new LocationStore(context, queue, null, null);
+    locationStore = new LocationStore(context, queue, null, "");
   }
 }


### PR DESCRIPTION
# Description 

Add blacklist to `AnalyticsBroadcaster` to avoid infinite loops.

Adds manifest-config annotations processor to lookup custom analytics
domain and replace manual manifest config lookups of config API url
prefix, location API url prefix, app id and app key.

This also removes non-null values for URLs in config and location
request models, which simplifies the implementation further.

Addresses SDKCF-758 and APTT-661

See https://github.com/rakutentech/android-manifest-config

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [ ] I ran `./gradlew check` without errors
