### PR TITLE
bugfix: Tracker was being disabled after sending an analytics event

### DIFF
--- a/performance-tracking-core/src/main/java/com/rakuten/tech/mobile/perf/core/Analytics.java
+++ b/performance-tracking-core/src/main/java/com/rakuten/tech/mobile/perf/core/Analytics.java
@@ -1,11 +1,13 @@
 package com.rakuten.tech.mobile.perf.core;
 
+import android.util.Log;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
 public abstract class Analytics {
   public static final String CDN_HEADER = "X-CDN-Served-From";
+  private static final String TAG = "Performance Tracking";
 
   @SuppressWarnings("WeakerAccess")
   public abstract void sendEvent(String name, Map<String, ?> data);
@@ -21,32 +23,36 @@ public abstract class Analytics {
   };
 
   void sendUrlMeasurement(Measurement m, String cdnHeader, long contentLength) {
-    if(isUrlBlacklisted(String.valueOf(m.a))) {
-      return;
+    try {
+      if(isUrlBlacklisted(String.valueOf(m.a))) {
+        return;
+      }
+      Map<String, Object> event =  new HashMap<>();
+
+      Map<String, Object> entry =  new HashMap<>();
+      entry.put("name", m.a);
+      entry.put("startTime", m.startTime);
+      entry.put("responseEnd", m.endTime);
+      entry.put("duration", m.endTime - m.startTime);
+      if(cdnHeader != null && cdnHeader.length() > 0) {
+        entry.put("cdn", cdnHeader);
+      }
+      if (contentLength > 0) {
+        entry.put("transferSize", contentLength);
+      }
+
+      ArrayList<Map> entries = new ArrayList<>(1);
+      entries.add(entry);
+
+      Map<String, Object> data =  new HashMap<>();
+      data.put("type", "resource");
+      data.put("entries", entries);
+
+      event.put("perfdata", data);
+
+      sendEvent("perf", event);
+    } catch (Exception e) {
+      Log.d(TAG, "Failed to send Measurement to Analytics: " + e.getMessage());
     }
-    Map<String, Object> event =  new HashMap<>();
-
-    Map<String, Object> entry =  new HashMap<>();
-    entry.put("name", m.a);
-    entry.put("startTime", m.startTime);
-    entry.put("responseEnd", m.endTime);
-    entry.put("duration", m.endTime - m.startTime);
-    if(cdnHeader != null && cdnHeader.length() > 0) {
-      entry.put("cdn", cdnHeader);
-    }
-    if (contentLength > 0) {
-      entry.put("transferSize", contentLength);
-    }
-
-    ArrayList<Map> entries = new ArrayList<>(1);
-    entries.add(entry);
-
-    Map<String, Object> data =  new HashMap<>();
-    data.put("type", "resource");
-    data.put("entries", entries);
-
-    event.put("perfdata", data);
-
-    sendEvent("perf", event);
   }
 }

--- a/performance-tracking-core/src/main/java/com/rakuten/tech/mobile/perf/core/Analytics.java
+++ b/performance-tracking-core/src/main/java/com/rakuten/tech/mobile/perf/core/Analytics.java
@@ -21,7 +21,7 @@ public abstract class Analytics {
   };
 
   void sendUrlMeasurement(Measurement m, String cdnHeader, long contentLength) {
-    if(isUrlBlacklisted((String) m.a)) {
+    if(isUrlBlacklisted(String.valueOf(m.a))) {
       return;
     }
     Map<String, Object> event =  new HashMap<>();

--- a/performance-tracking-core/src/main/java/com/rakuten/tech/mobile/perf/core/TrackerImpl.java
+++ b/performance-tracking-core/src/main/java/com/rakuten/tech/mobile/perf/core/TrackerImpl.java
@@ -1,9 +1,5 @@
 package com.rakuten.tech.mobile.perf.core;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-
 class TrackerImpl {
 
   private String activityName = null;

--- a/performance-tracking-core/src/test/java/com/rakuten/tech/mobile/perf/core/AnalyticsSpec.java
+++ b/performance-tracking-core/src/test/java/com/rakuten/tech/mobile/perf/core/AnalyticsSpec.java
@@ -2,6 +2,8 @@ package com.rakuten.tech.mobile.perf.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import org.junit.Before;
@@ -46,11 +48,11 @@ public class AnalyticsSpec {
   private Measurement measurement;
 
   @Before
-  public void setup() {
+  public void setup() throws MalformedURLException {
     measurement = new Measurement();
     measurement.startTime = 1000;
     measurement.endTime = 2000;
-    measurement.a = "http://example.com";
+    measurement.a = new URL("http://example.com");
     measurement.b = "GET";
     measurement.c = 201;
   }

--- a/performance-tracking-core/src/test/java/com/rakuten/tech/mobile/perf/core/AnalyticsSpec.java
+++ b/performance-tracking-core/src/test/java/com/rakuten/tech/mobile/perf/core/AnalyticsSpec.java
@@ -6,6 +6,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import junit.framework.TestCase;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -120,5 +121,22 @@ public class AnalyticsSpec {
     analytics.sendUrlMeasurement(measurement, "", 0);
 
     assertThat(capture.entry).doesNotContainKeys("cdn");
+  }
+
+  @Test
+  public void shouldCatchExceptions() {
+    Analytics exceptionAnalytics = new Analytics() {
+      @SuppressWarnings("unchecked")
+      @Override
+      public void sendEvent(String name, Map<String, ?> data) {
+        throw new RuntimeException("Error message");
+      }
+    };
+
+    try {
+      exceptionAnalytics.sendUrlMeasurement(measurement, null, 0);
+    } catch (Exception e) {
+      TestCase.fail();
+    }
   }
 }


### PR DESCRIPTION
# Description 
In 'Analytics' class, the  Measurement's URL field is being cast to a String, however this throws an error if the field is a URL instance. This would then trigger the fail-safe for the Tracker, and disable performance tracking. This commit uses 'String#valueOf' instead of casting

## Links
[SDKCF-758]

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
