### PR TITLE
Add config flags to enable/disable sending events to Performance Tracking and/or Analytics

### DIFF
--- a/performance-tracking-core/src/main/java/com/rakuten/tech/mobile/perf/core/Config.java
+++ b/performance-tracking-core/src/main/java/com/rakuten/tech/mobile/perf/core/Config.java
@@ -15,4 +15,6 @@ public class Config {
   public boolean debug;
   public String relayAppId;
   public boolean enableNonMetricMeasurement;
+  public boolean enablePerfTrackingEvents;
+  public boolean enableAnalyticsEvents;
 }

--- a/performance-tracking-core/src/main/java/com/rakuten/tech/mobile/perf/core/EventWriter.java
+++ b/performance-tracking-core/src/main/java/com/rakuten/tech/mobile/perf/core/EventWriter.java
@@ -12,101 +12,101 @@ import javax.net.ssl.HttpsURLConnection;
 class EventWriter {
 
   private final String TAG = "Performance Tracking";
-  private final Config _config;
-  private final EnvironmentInfo _envInfo;
-  private final URL _url;
-  private HttpsURLConnection _conn;
-  private BufferedWriter _writer;
-  private int _measurements;
+  private final Config config;
+  private final EnvironmentInfo envInfo;
+  private final URL url;
+  private HttpsURLConnection connection;
+  private BufferedWriter writer;
+  private int measurements;
 
   EventWriter(Config config, EnvironmentInfo envInfo) {
-    _config = config;
-    _envInfo = envInfo;
+    this.config = config;
+    this.envInfo = envInfo;
     URL url = null;
     try {
-      url = new URL(_config.eventHubUrl);
+      url = new URL(this.config.eventHubUrl);
     } catch (MalformedURLException e) {
-      if (_config.debug) {
+      if (this.config.debug) {
         Log.d(TAG, e.getMessage());
       }
     } finally {
-      _url = url;
+      this.url = url;
     }
   }
 
   /* for testing */
   @SuppressWarnings("unused") EventWriter(Config config, EnvironmentInfo envInfo, URL url) {
-    _config = config;
-    _envInfo = envInfo;
-    _url = url;
+    this.config = config;
+    this.envInfo = envInfo;
+    this.url = url;
   }
 
   void begin() throws IOException {
-    if (!_config.enablePerfTrackingEvents) {
+    if (!config.enablePerfTrackingEvents) {
       return;
     }
 
     try {
-      _conn = (HttpsURLConnection) _url.openConnection();
-      _conn.setRequestMethod("POST");
-      for (Map.Entry<String, String> entry : _config.header.entrySet()) {
-        _conn.setRequestProperty(entry.getKey(), entry.getValue());
+      connection = (HttpsURLConnection) url.openConnection();
+      connection.setRequestMethod("POST");
+      for (Map.Entry<String, String> entry : config.header.entrySet()) {
+        connection.setRequestProperty(entry.getKey(), entry.getValue());
       }
-      _conn.setUseCaches(false);
-      _conn.setDoInput(false);
-      _conn.setDoOutput(true);
-      _conn.connect();
+      connection.setUseCaches(false);
+      connection.setDoInput(false);
+      connection.setDoOutput(true);
+      connection.connect();
 
-      _writer = new BufferedWriter(new OutputStreamWriter(_conn.getOutputStream()));
-      _writer.append("{\"app\":\"").append(_config.app).append("\"")
-          .append(",\"version\":\"").append(_config.version).append("\"")
-          .append(",\"relay_app_id\":\"").append(_config.relayAppId).append("\"");
+      writer = new BufferedWriter(new OutputStreamWriter(connection.getOutputStream()));
+      writer.append("{\"app\":\"").append(config.app).append("\"")
+          .append(",\"version\":\"").append(config.version).append("\"")
+          .append(",\"relay_app_id\":\"").append(config.relayAppId).append("\"");
 
-      if (_envInfo.device != null) {
-        _writer.append(",\"device\":\"").append(_envInfo.device).append("\"");
-      }
-
-      if (_envInfo.getAppUsedMemory() > 0) {
-        _writer.append(",\"app_mem_used\":").append(Long.toString(_envInfo.getAppUsedMemory()));
+      if (envInfo.device != null) {
+        writer.append(",\"device\":\"").append(envInfo.device).append("\"");
       }
 
-      if (_envInfo.getDeviceFreeMemory() > 0) {
-        _writer.append(",\"device_mem_free\":").append(Long.toString(_envInfo.getDeviceFreeMemory()));
+      if (envInfo.getAppUsedMemory() > 0) {
+        writer.append(",\"app_mem_used\":").append(Long.toString(envInfo.getAppUsedMemory()));
       }
 
-      if (_envInfo.getDeviceTotalMemory() > 0) {
-        _writer.append(",\"device_mem_total\":").append(Long.toString(_envInfo.getDeviceTotalMemory()));
+      if (envInfo.getDeviceFreeMemory() > 0) {
+        writer.append(",\"device_mem_free\":").append(Long.toString(envInfo.getDeviceFreeMemory()));
       }
 
-      if (_envInfo.getBatteryLevel() > 0) {
-        _writer.append(",\"battery_level\":").append(Float.toString(_envInfo.getBatteryLevel()));
+      if (envInfo.getDeviceTotalMemory() > 0) {
+        writer.append(",\"device_mem_total\":").append(Long.toString(envInfo.getDeviceTotalMemory()));
       }
 
-      if (_envInfo.getCountry() != null) {
-        _writer.append(",\"country\":\"").append(_envInfo.getCountry()).append("\"");
+      if (envInfo.getBatteryLevel() > 0) {
+        writer.append(",\"battery_level\":").append(Float.toString(envInfo.getBatteryLevel()));
       }
 
-      if (_envInfo.getRegion() != null) {
-        _writer.append(",\"region\":\"").append(_envInfo.getRegion()).append("\"");
+      if (envInfo.getCountry() != null) {
+        writer.append(",\"country\":\"").append(envInfo.getCountry()).append("\"");
       }
 
-      if (_envInfo.network != null) {
-        _writer.append(",\"network\":\"").append(_envInfo.network).append("\"");
+      if (envInfo.getRegion() != null) {
+        writer.append(",\"region\":\"").append(envInfo.getRegion()).append("\"");
       }
 
-      if (_envInfo.osName != null) {
-        _writer.append(",\"os\":\"").append(_envInfo.osName).append("\"");
+      if (envInfo.network != null) {
+        writer.append(",\"network\":\"").append(envInfo.network).append("\"");
       }
 
-      if (_envInfo.osVersion != null) {
-        _writer.append(",\"os_version\":\"").append(_envInfo.osVersion).append("\"");
+      if (envInfo.osName != null) {
+        writer.append(",\"os\":\"").append(envInfo.osName).append("\"");
       }
 
-      _writer.append(",\"measurements\":[");
-      _measurements = 0;
+      if (envInfo.osVersion != null) {
+        writer.append(",\"os_version\":\"").append(envInfo.osVersion).append("\"");
+      }
+
+      writer.append(",\"measurements\":[");
+      measurements = 0;
 
     } catch (Exception e) {
-      if (_config.debug) {
+      if (config.debug) {
         Log.d(TAG, e.getMessage());
       }
       disconnect();
@@ -117,23 +117,23 @@ class EventWriter {
   }
 
   void write(Metric metric) throws IOException {
-    if (!_config.enablePerfTrackingEvents || _writer == null) {
+    if (!config.enablePerfTrackingEvents || writer == null) {
       return;
     }
 
     try {
-      if (_measurements > 0) {
-        _writer.append(',');
+      if (measurements > 0) {
+        writer.append(',');
       }
-      _writer
+      writer
           .append("{\"metric\":\"").append(metric.id).append("\"")
           .append(",\"urls\":").append(Long.toString(metric.urls))
           .append(",\"start\":").append(Long.toString(metric.startTime))
           .append(",\"time\":").append(Long.toString(metric.endTime - metric.startTime))
           .append('}');
-      _measurements++;
+      measurements++;
     } catch (Exception e) {
-      if (_config.debug) {
+      if (config.debug) {
         Log.d(TAG, e.getMessage());
       }
       disconnect();
@@ -144,27 +144,27 @@ class EventWriter {
   }
 
   void write(Measurement m, String metricId) throws IOException {
-    if (!_config.enablePerfTrackingEvents || _writer == null) {
+    if (!config.enablePerfTrackingEvents || writer == null) {
       return;
     }
 
     try {
-      if (_measurements > 0) {
-        _writer.append(',');
+      if (measurements > 0) {
+        writer.append(',');
       }
 
       switch (m.type) {
         case Measurement.METHOD:
-          _writer.append("{\"method\":\"").append((String) m.a).append('.').append((String) m.b)
+          writer.append("{\"method\":\"").append((String) m.a).append('.').append((String) m.b)
               .append('"');
           break;
 
         case Measurement.URL:
-          _writer.append("{\"url\":\"");
+          writer.append("{\"url\":\"");
 
           if (m.a instanceof URL) {
             URL url = (URL) m.a;
-            _writer.append(url.getProtocol()).append("://").append(url.getAuthority())
+            writer.append(url.getProtocol()).append("://").append(url.getAuthority())
                 .append(escapeValue(url.getPath()));
           } else {
             String url = (String) m.a;
@@ -172,21 +172,21 @@ class EventWriter {
             if (q > 0) {
               url = url.substring(0, q);
             }
-            _writer.append(escapeValue(url));
+            writer.append(escapeValue(url));
           }
 
-          _writer.append('"');
+          writer.append('"');
 
           if (m.b != null) {
-            _writer.append(",\"verb\":\"").append((String) m.b).append('"');
+            writer.append(",\"verb\":\"").append((String) m.b).append('"');
           }
           if (m.c != null) {
-            _writer.append(",\"status_code\":").append(m.c.toString());
+            writer.append(",\"status_code\":").append(m.c.toString());
           }
           break;
 
         case Measurement.CUSTOM:
-          _writer.append("{\"custom\":\"").append((String) m.a).append('"');
+          writer.append("{\"custom\":\"").append((String) m.a).append('"');
           break;
 
         default:
@@ -194,17 +194,17 @@ class EventWriter {
       }
 
       if (m.activityName != null && m.activityName.length() > 0) {
-        _writer.append(",\"screen\":\"").append(m.activityName).append('"');
+        writer.append(",\"screen\":\"").append(m.activityName).append('"');
       }
 
       if (metricId != null) {
-        _writer.append(",\"metric\":\"").append(metricId).append('"');
+        writer.append(",\"metric\":\"").append(metricId).append('"');
       }
-      _writer.append(",\"start\":").append(Long.toString(m.startTime));
-      _writer.append(",\"time\":").append(Long.toString(m.endTime - m.startTime)).append('}');
-      _measurements++;
+      writer.append(",\"start\":").append(Long.toString(m.startTime));
+      writer.append(",\"time\":").append(Long.toString(m.endTime - m.startTime)).append('}');
+      measurements++;
     } catch (Exception e) {
-      if (_config.debug) {
+      if (config.debug) {
         Log.d(TAG, e.getMessage());
       }
       disconnect();
@@ -215,23 +215,23 @@ class EventWriter {
   }
 
   void end() throws IOException {
-    if (!_config.enablePerfTrackingEvents) {
+    if (!config.enablePerfTrackingEvents) {
       return;
     }
 
     try {
-      if (_writer != null) {
-        _writer.append("]}");
-        _writer.close();
+      if (writer != null) {
+        writer.append("]}");
+        writer.close();
 
-        int result = _conn.getResponseCode();
+        int result = connection.getResponseCode();
 
         if (result != 201) {
           throw new EventHubException(result);
         }
       }
     } catch (Exception e) {
-      if (_config.debug) {
+      if (config.debug) {
         Log.d(TAG, e.getMessage());
       }
       if (e instanceof EventHubException) {
@@ -243,19 +243,19 @@ class EventWriter {
   }
 
   private void disconnect() {
-    if (_conn != null) {
-      _conn.disconnect();
-      _conn = null;
+    if (connection != null) {
+      connection.disconnect();
+      connection = null;
     }
-    if (_writer != null) {
+    if (writer != null) {
       try {
-        _writer.close();
+        writer.close();
       } catch (IOException e) {
-        if (_config.debug) {
+        if (config.debug) {
           Log.d(TAG, e.getMessage());
         }
       }
-      _writer = null;
+      writer = null;
     }
   }
 

--- a/performance-tracking-core/src/main/java/com/rakuten/tech/mobile/perf/core/SenderThread.java
+++ b/performance-tracking-core/src/main/java/com/rakuten/tech/mobile/perf/core/SenderThread.java
@@ -5,10 +5,10 @@ class SenderThread extends Thread {
   private static final int SLEEP_INTERVAL_MILLISECONDS = 10_000;
   private static final int SLEEP_MAX_INTERVAL_MILLISECONDS = 1_800_000;
 
-  private final Sender _sender;
-  private final int _interval;
-  private volatile boolean _run = true;
-  private int _failures = 0;
+  private final Sender sender;
+  private final int interval;
+  private volatile boolean run = true;
+  private int failures = 0;
 
   SenderThread(Sender sender) {
     this(sender, SLEEP_INTERVAL_MILLISECONDS);
@@ -16,12 +16,12 @@ class SenderThread extends Thread {
 
   @SuppressWarnings("WeakerAccess") /* for testing */
   SenderThread(Sender sender, int sleepInterval) {
-    _interval = sleepInterval;
-    _sender = sender;
+    interval = sleepInterval;
+    this.sender = sender;
   }
 
   void terminate() {
-    _run = false;
+    run = false;
   }
 
   @Override
@@ -29,23 +29,23 @@ class SenderThread extends Thread {
 
     int index = 1;
 
-    while (_run) {
+    while (run) {
       try {
-        index = _sender.send(index);
-        _failures = 0;
+        index = sender.send(index);
+        failures = 0;
       } catch (EventHubException e) {
         if (e.statusCode == 401) {
           Tracker.off();
           return;
         } else {
-          _failures++;
+          failures++;
         }
       } catch (Throwable ignored) {
-        _failures++;
+        failures++;
       }
 
       try {
-        int sleepTime = (int) Math.min(Math.pow(2, Math.min(_failures, 10)) * _interval,
+        int sleepTime = (int) Math.min(Math.pow(2, Math.min(failures, 10)) * interval,
             SLEEP_MAX_INTERVAL_MILLISECONDS);
         Thread.sleep(sleepTime);
       } catch (InterruptedException e) { /* continue looping if sleep is interrupted */ }

--- a/performance-tracking-core/src/main/java/com/rakuten/tech/mobile/perf/core/Tracker.java
+++ b/performance-tracking-core/src/main/java/com/rakuten/tech/mobile/perf/core/Tracker.java
@@ -13,8 +13,8 @@ import java.net.URL;
 @SuppressWarnings({"unused", "WeakerAccess"})
 public class Tracker {
 
-  private static TrackerImpl _tracker;
-  private static SenderThread _senderThread;
+  private static TrackerImpl tracker;
+  private static SenderThread senderThread;
 
   /**
    * Turns performance tracking on.
@@ -28,31 +28,31 @@ public class Tracker {
     Debug debug = config.debug ? new Debug() : null;
     MeasurementBuffer buffer = new MeasurementBuffer();
     Current current = new Current();
-    _tracker = new TrackerImpl(buffer, current, debug, analytics, config.enableNonMetricMeasurement);
+    tracker = new TrackerImpl(buffer, current, debug, analytics, config.enableNonMetricMeasurement);
     EnvironmentInfo envInfo = new EnvironmentInfo(context, locationObservable, batteryInfoObservable);
     EventWriter writer = new EventWriter(config, envInfo);
     Sender sender = new Sender(buffer, current, writer, debug, config.enableNonMetricMeasurement);
-    _senderThread = new SenderThread(sender);
-    _senderThread.start();
+    senderThread = new SenderThread(sender);
+    senderThread.start();
   }
 
   /**
    * Turns performance tracking off.
    */
   public static synchronized void off() {
-    _tracker = null;
-    SenderThread s = _senderThread;
+    tracker = null;
+    SenderThread s = senderThread;
     if (s != null) {
       s.terminate();
     }
-    _senderThread = null;
+    senderThread = null;
   }
 
   /**
    * Returns performance tracking status.
    */
   public static boolean isTrackerRunning() {
-    return _tracker != null;
+    return tracker != null;
   }
 
   /**
@@ -61,7 +61,7 @@ public class Tracker {
    */
   public static void startMetric(String metricId) {
     try {
-      TrackerImpl t = _tracker;
+      TrackerImpl t = tracker;
       if (t != null) {
         t.startMetric(metricId);
       }
@@ -75,7 +75,7 @@ public class Tracker {
    */
   public static void prolongMetric() {
     try {
-      TrackerImpl t = _tracker;
+      TrackerImpl t = tracker;
       if (t != null) {
         t.prolongMetric();
       }
@@ -89,7 +89,7 @@ public class Tracker {
    */
   public static void endMetric() {
     try {
-      TrackerImpl t = _tracker;
+      TrackerImpl t = tracker;
       if (t != null) {
         t.endMetric();
       }
@@ -106,7 +106,7 @@ public class Tracker {
    */
   public static int startMethod(Object object, String method) {
     try {
-      TrackerImpl t = _tracker;
+      TrackerImpl t = tracker;
       return t != null ? t.startMethod(object, method) : 0;
     } catch (Throwable t) {
       Tracker.off();
@@ -120,7 +120,7 @@ public class Tracker {
    */
   public static void endMethod(int trackingId) {
     try {
-      TrackerImpl t = _tracker;
+      TrackerImpl t = tracker;
       if (t != null) {
         t.endMethod(trackingId);
       }
@@ -137,7 +137,7 @@ public class Tracker {
    */
   public static int startUrl(URL url, String verb) {
     try {
-      TrackerImpl t = _tracker;
+      TrackerImpl t = tracker;
       return t != null ? t.startUrl(url, verb) : 0;
     } catch (Throwable t) {
       Tracker.off();
@@ -153,7 +153,7 @@ public class Tracker {
    */
   public static int startUrl(String url, String verb) {
     try {
-      TrackerImpl t = _tracker;
+      TrackerImpl t = tracker;
       return t != null ? t.startUrl(url, verb) : 0;
     } catch (Throwable t) {
       Tracker.off();
@@ -169,7 +169,7 @@ public class Tracker {
    */
   public static void endUrl(int trackingId, int statusCode, String cdnHeader, long contentLength) {
     try {
-      TrackerImpl t = _tracker;
+      TrackerImpl t = tracker;
       if (t != null) {
         t.endUrl(trackingId, statusCode, cdnHeader, contentLength);
       }
@@ -185,7 +185,7 @@ public class Tracker {
    */
   public static int startCustom(String measurementId) {
     try {
-      TrackerImpl t = _tracker;
+      TrackerImpl t = tracker;
       return t != null ? t.startCustom(measurementId) : 0;
     } catch (Throwable t) {
       Tracker.off();
@@ -199,7 +199,7 @@ public class Tracker {
    */
   public static void endCustom(int trackingId) {
     try {
-      TrackerImpl t = _tracker;
+      TrackerImpl t = tracker;
       if (t != null) {
         t.endCustom(trackingId);
       }
@@ -214,7 +214,7 @@ public class Tracker {
    */
   public static void updateActivityName(String name) {
     try {
-      TrackerImpl t = _tracker;
+      TrackerImpl t = tracker;
       if (t != null) {
         t.updateActivityName(name);
       }
@@ -229,7 +229,7 @@ public class Tracker {
    */
   public static void clearActivityName(String name) {
     try {
-      TrackerImpl t = _tracker;
+      TrackerImpl t = tracker;
       if (t != null) {
         t.clearActivityName(name);
       }

--- a/performance-tracking-core/src/test/java/com/rakuten/tech/mobile/perf/core/EventWriterSpec.java
+++ b/performance-tracking-core/src/test/java/com/rakuten/tech/mobile/perf/core/EventWriterSpec.java
@@ -1,8 +1,10 @@
 package com.rakuten.tech.mobile.perf.core;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -11,9 +13,11 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
 import javax.net.ssl.HttpsURLConnection;
+import junit.framework.TestCase;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -23,17 +27,18 @@ import org.mockito.MockitoAnnotations;
 import org.omg.CORBA.portable.OutputStream;
 import org.skyscreamer.jsonassert.JSONAssert;
 
+@Ignore
 public class EventWriterSpec {
 
-  private Config config;
-  private EnvironmentInfo envInfo;
+  Config config;
+  EnvironmentInfo envInfo;
   @Mock URL url;
   @Mock OutputStream outputStream;
   @Mock HttpsURLConnection conn;
   @Mock Context ctx;
-  final private CachingObservable<LocationData> location = new CachingObservable<>(null);
-  final private CachingObservable<Float> batteryinfo = new CachingObservable<Float>(null);
-  private EventWriter writer;
+  private final CachingObservable<LocationData> location = new CachingObservable<>(null);
+  private final CachingObservable<Float> batteryinfo = new CachingObservable<Float>(null);
+  EventWriter writer;
 
   @Before public void initMocks() throws IOException {
     MockitoAnnotations.initMocks(this);
@@ -44,6 +49,7 @@ public class EventWriterSpec {
     config.debug = true;
     config.eventHubUrl = ""; // url injected via constructor
     config.header = new HashMap<>();
+    config.enablePerfTrackingEvents = true;
     envInfo = new EnvironmentInfo(ctx, location, batteryinfo);
     location.publish(new LocationData("test-land", "test-region"));
     envInfo.network = "test-network";
@@ -53,389 +59,446 @@ public class EventWriterSpec {
     when(url.openConnection()).thenReturn(conn);
     when(conn.getOutputStream()).thenReturn(outputStream);
     when(conn.getResponseCode()).thenReturn(201);
-
-    writer = new EventWriter(config, envInfo, url);
-    assertThat(writer).isNotNull();
   }
 
-  @Rule public TestData emptyMyJson = new TestData("memory_measurement.json");
+  public static class NormalEventWriterBehaviorSpec extends EventWriterSpec {
+    @Before public void setup() throws IOException {
+      writer = new EventWriter(config, envInfo, url);
+      assertThat(writer).isNotNull();
+    }
 
-  @Test public void shouldWriteMemoryAndBatteryDetailsIntoMeasurement()
-      throws IOException, JSONException {
+    @Rule public TestData emptyMyJson = new TestData("memory_measurement.json");
 
-    EnvironmentInfo myEnvInfo = Mockito.spy(envInfo);
-    doReturn(2000L).when(myEnvInfo).getDeviceTotalMemory();
-    doReturn(500L).when(myEnvInfo).getDeviceFreeMemory();
-    doReturn(0.3f).when(myEnvInfo).getBatteryLevel();
-    doReturn(100L).when(myEnvInfo).getAppUsedMemory();
+    @Test public void shouldWriteMemoryAndBatteryDetailsIntoMeasurement()
+        throws IOException, JSONException {
 
-    EventWriter myWriter = new EventWriter(config, myEnvInfo, url);
-    myWriter.begin();
-    myWriter.end();
+      EnvironmentInfo myEnvInfo = Mockito.spy(envInfo);
+      doReturn(2000L).when(myEnvInfo).getDeviceTotalMemory();
+      doReturn(500L).when(myEnvInfo).getDeviceFreeMemory();
+      doReturn(0.3f).when(myEnvInfo).getBatteryLevel();
+      doReturn(100L).when(myEnvInfo).getAppUsedMemory();
 
-    String writtenJson = extractWrittenString(outputStream);
-    JSONAssert.assertEquals(emptyMyJson.content, writtenJson, true);
+      EventWriter myWriter = new EventWriter(config, myEnvInfo, url);
+      myWriter.begin();
+      myWriter.end();
 
-  }
-  // creation & init
+      String writtenJson = extractWrittenString(outputStream);
+      JSONAssert.assertEquals(emptyMyJson.content, writtenJson, true);
 
-  @Test public void shouldOpenConnectionOnBegin() throws IOException {
-    writer = new EventWriter(config, envInfo, null);
+    }
+    // creation & init
 
-    writer.begin();
+    @Test public void shouldOpenConnectionOnBegin() throws IOException {
+      writer = new EventWriter(config, envInfo, null);
 
-    // Verify no exception
-  }
-
-  @Test public void shouldDisconnectOnFailure() throws IOException {
-    when(conn.getOutputStream()).thenThrow(new IOException());
-
-    try {
       writer.begin();
-    } catch (IOException ignored) {
+
+      // Verify no exception
     }
 
-    verify(conn).disconnect();
-  }
-
-  @Test public void shouldFailSilentlyOnBadUrl() throws IOException {
-
-    writer.begin();
-    verify(url).openConnection();
-    verify(conn).getOutputStream();
-  }
-
-  @Test public void shouldConfigureConnectionOnBegin() throws IOException {
-    config.header.put("test-header", "test-header-value");
-    writer.begin();
-    verify(conn).setRequestMethod("POST");
-    verify(conn).setRequestProperty("test-header", "test-header-value");
-    verify(conn).setUseCaches(false);
-    verify(conn).setDoInput(false);
-    verify(conn).setDoOutput(true);
-  }
-
-  // writing
-
-  @Rule public TestData emptyJson = new TestData("no_measurement.json");
-
-  @Test public void shouldWriteConfigAndEnvInfo() throws IOException, JSONException {
-    writer.begin();
-    writer.end();
-
-    String writtenJson = trimAppMemDetails(extractWrittenString(outputStream));
-    JSONAssert.assertEquals(emptyJson.content, writtenJson, true);
-  }
-
-  @Rule public TestData emptyNoEnvJson = new TestData("no_measurement_no_env.json");
-
-  @Test public void shouldHandleNullsInEnvInfo() throws IOException, JSONException {
-    envInfo.device = null;
-    envInfo.network = null;
-
-    writer.begin();
-    writer.end();
-
-    String writtenJson = trimAppMemDetails(extractWrittenString(outputStream));
-    JSONAssert.assertEquals(emptyNoEnvJson.content, writtenJson, true);
-  }
-
-  @Rule public TestData metricJson = new TestData("metric.json");
-
-  @Test public void shouldWriteSingleMetric() throws IOException, JSONException {
-    Metric metric = new Metric();
-    metric.startTime = 0L;
-    metric.endTime = 999;
-    metric.id = "test-metric";
-    metric.urls = 999;
-
-    writer.begin();
-    writer.write(metric);
-    writer.end();
-
-    String writtenString = trimAppMemDetails(extractWrittenString(outputStream));
-    JSONAssert.assertEquals(metricJson.content, writtenString, true);
-  }
-
-  @Rule public TestData methodMeasurementJson = new TestData("method_measurement.json");
-
-  @Test public void shouldWriteSingleMethodMeasurement() throws JSONException, IOException {
-    Measurement measurement = new Measurement();
-    measurement.type = Measurement.METHOD;
-    measurement.a = "TestClass";
-    measurement.b = "testMethod";
-    measurement.startTime = 0L;
-    measurement.endTime = 999;
-
-    writer.begin();
-    writer.write(measurement, "test-metric");
-    writer.end();
-
-    String writtenString = trimAppMemDetails(extractWrittenString(outputStream));
-    JSONAssert.assertEquals(methodMeasurementJson.content, writtenString, true);
-  }
-
-  @Rule public TestData urlMeasurementJson = new TestData("url_measurement.json");
-
-  @Test public void shouldWriteUrlObjectMeasurement() throws JSONException, IOException {
-    Measurement measurement = new Measurement();
-    measurement.type = Measurement.URL;
-    measurement.a = new URL("https://rakuten.co.jp/some/path?and=some&url=params");
-    measurement.b = "VERB";
-    measurement.c = 200;
-    measurement.startTime = 0L;
-    measurement.endTime = 999;
-
-    writer.begin();
-    writer.write(measurement, "test-metric");
-    writer.end();
-
-    String writtenString = trimAppMemDetails(extractWrittenString(outputStream));
-    JSONAssert.assertEquals(urlMeasurementJson.content, writtenString, true);
-  }
-
-  @Test public void shouldWriteUrlStringMeasurement() throws JSONException, IOException {
-    Measurement measurement = new Measurement();
-    measurement.type = Measurement.URL;
-    measurement.a = "https://rakuten.co.jp/some/path?and=some&url=params";
-    measurement.b = "VERB";
-    measurement.c = 200;
-    measurement.startTime = 0L;
-    measurement.endTime = 999;
-
-    writer.begin();
-    writer.write(measurement, "test-metric");
-    writer.end();
-
-    String writtenString = trimAppMemDetails(extractWrittenString(outputStream));
-    JSONAssert.assertEquals(urlMeasurementJson.content, writtenString, true);
-  }
-
-  @Rule public TestData customMeasurementJson = new TestData("custom_measurement.json");
-
-  @Test public void shouldWriteSingleCustomMeasurement() throws JSONException, IOException {
-    Measurement measurement = new Measurement();
-    measurement.type = Measurement.CUSTOM;
-    measurement.a = "custom-measurement";
-    measurement.startTime = 0L;
-    measurement.endTime = 999;
-    measurement.activityName = "test-activity";
-
-    writer.begin();
-    writer.write(measurement, "test-metric");
-    writer.end();
-
-    String writtenString = trimAppMemDetails(extractWrittenString(outputStream));
-    JSONAssert.assertEquals(customMeasurementJson.content, writtenString, true);
-  }
-
-  // silent exception handling
-
-  @Test public void shouldNotFailOnBadUrl() {
-    config.eventHubUrl = "usnteaueau";
-    writer = new EventWriter(config, envInfo);
-    // no exceptions
-  }
-
-  @Test public void shouldNotFailOnGoodUrl() {
-    config.eventHubUrl = "https://rakuten.co.jp";
-    writer = new EventWriter(config, envInfo);
-    // no exceptions
-  }
-
-  @Test public void shouldNotFailOnWritingNull() throws IOException {
-    writer.write(null);
-    writer.write(null, null);
-
-    writer.begin();
-    writer.write(null);
-    writer.write(null, null);
-    writer.end();
-    // no exceptions
-  }
-
-  @Test public void shouldNotFailOnWriteWithoutBegin() throws IOException {
-    Measurement measurement = new Measurement();
-    measurement.type = Measurement.CUSTOM;
-    measurement.a = "";
-    measurement.startTime = 0L;
-    measurement.endTime = 999;
-    writer.write(measurement, "");
-    // no exceptions
-  }
-
-  @Test public void shouldNotFailOnNullPayload() throws IOException {
-    Measurement measurement = new Measurement();
-    measurement.type = Measurement.CUSTOM;
-    measurement.a = null;
-    measurement.b = null;
-    measurement.startTime = 0L;
-    measurement.endTime = 999;
-    writer.begin();
-    writer.write(measurement, null);
-    measurement.type = Measurement.METHOD;
-    writer.write(measurement, null);
-    measurement.type = Measurement.URL;
-    writer.write(measurement, null);
-    measurement.type = Measurement.METRIC;
-    writer.write(measurement, null);
-    measurement.type = 5; // invalid type
-    writer.write(measurement, null);
-
-    Metric metric = new Metric();
-    metric.startTime = 0L;
-    metric.endTime = 999;
-    metric.id = null;
-    metric.urls = 999;
-    writer.write(metric);
-    writer.end();
-    // no exceptions
-  }
-
-  @Test public void shouldNotFailOnIncorrectEnd() throws IOException {
-    writer.end();
-    writer.begin();
-    writer.end();
-    writer.end();
-    // no exceptions
-  }
-
-  @Rule public TestData escapedJson = new TestData("escaped.json");
-
-  @Test public void shouldHandleMalformedURLData() throws IOException, JSONException {
-    Measurement measurement = new Measurement();
-    measurement.type = Measurement.URL;
-    measurement.a = new URL("http://example.com:80/page1\".html");
-    measurement.startTime = 0L;
-    measurement.endTime = 999;
-
-    writer.begin();
-    writer.write(measurement, "test-metric");
-    measurement.a = new URL("http://example.com:80/page1\"[.html");
-    writer.write(measurement, "test-metric");
-    measurement.a = new URL("http://example.com:80/page1\"{.html");
-    writer.write(measurement, "test-metric");
-    measurement.a = new URL("http://example.com:80/page1\",.html");
-    writer.write(measurement, "test-metric");
-    measurement.a = new URL("http://example.com:80/page1'}'.html");
-    writer.write(measurement, "test-metric");
-    //For URL as String.
-    measurement.a = "http://example.com:80/page1\".html";
-    writer.write(measurement, "test-metric");
-    measurement.a = "http://example.com:80/page1\"[.html";
-    writer.write(measurement, "test-metric");
-    measurement.a = "http://example.com:80/page1\"{.html";
-    writer.write(measurement, "test-metric");
-    measurement.a = "http://example.com:80/page1\",.html";
-    writer.write(measurement, "test-metric");
-    measurement.a = "http://example.com:80/page1'}'.html";
-    writer.write(measurement, "test-metric");
-    writer.end();
-
-    String writtenString = trimAppMemDetails(extractWrittenString(outputStream));
-    JSONAssert.assertEquals(escapedJson.content, writtenString, true);
-  }
-
-  // smoke test
-
-  @Rule public TestData smokeTestJson = new TestData("smoke_test.json");
-
-  @Test public void smokeTest() throws IOException, JSONException {
-    Metric metric = new Metric();
-    metric.startTime = 0L;
-    metric.endTime = 999;
-    metric.id = "test-metric";
-    metric.urls = 999;
-
-    writer.begin();
-    writer.write(metric);
-    writer.write(metric);
-
-    Measurement measurement = new Measurement();
-    measurement.type = Measurement.METHOD;
-    measurement.a = "TestClass";
-    measurement.b = "testMethod";
-    measurement.startTime = 1L;
-    measurement.endTime = 999;
-
-    writer.write(measurement, metric.id);
-
-    measurement = new Measurement();
-    measurement.type = Measurement.URL;
-    measurement.a = "https://rakuten.co.jp1/some/path?and=some&url=params";
-    measurement.b = "VERB";
-    measurement.startTime = 10L;
-    measurement.endTime = 999;
-
-    writer.write(measurement, metric.id);
-
-    measurement = new Measurement();
-    measurement.type = Measurement.URL;
-    measurement.a = "https://rakuten.co.jp2/some/path?and=some&url=params";
-    measurement.b = "VERB";
-    measurement.startTime = 11L;
-    measurement.endTime = 999;
-
-    writer.write(measurement, null);
-
-    measurement = new Measurement();
-    measurement.type = Measurement.URL;
-    measurement.a = "https://rakuten.co.jp3/some/path?and=some&url=params";
-    measurement.b = null;
-    measurement.startTime = 100L;
-    measurement.endTime = 999;
-
-    writer.write(measurement, null);
-
-    measurement = new Measurement();
-    measurement.type = Measurement.CUSTOM;
-    measurement.a = "custom-measurement";
-    measurement.startTime = 101L;
-    measurement.endTime = 999;
-
-    writer.write(measurement, metric.id);
-
-    measurement = new Measurement();
-    measurement.type = Measurement.URL;
-    measurement.a = new URL("https://amazon.co.jp/other/path?and=some&url=params");
-    measurement.b = "BERV";
-    measurement.startTime = 0L;
-    measurement.endTime = 100;
-
-    writer.write(measurement, metric.id);
-
-    writer.end();
-
-    String writtenString = trimAppMemDetails(extractWrittenString(outputStream));
-    JSONAssert.assertEquals(smokeTestJson.content, writtenString, true);
-  }
-
-  // helpers
-
-  private String extractWrittenString(OutputStream outputStream) throws IOException {
-    ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
-    verify(outputStream).write(captor.capture(), anyInt(), anyInt());
-    byte[] writtenBytes = captor.getValue();
-    assertThat(writtenBytes).isNotEmpty();
-    return new String(writtenBytes);
-  }
-
-  /**
-   * Removes a key with name `app_mem_used` and its value from the input string
-   * Due to limitation we couldn't mock Runtime class native methods.
-   * Because of this we cannot validate App used memory in unit test. So removing `app_mem_used` field from actual string.
-   *
-   * @param input String
-   * @return String
-   */
-  private static String trimAppMemDetails(String input) {
-    JSONObject data = null;
-    try {
-      data = new JSONObject(input);
-      data.remove("app_mem_used");
-    } catch (JSONException e) {
-      e.printStackTrace();
+    @Test public void shouldDisconnectOnFailure() throws IOException {
+      when(conn.getOutputStream()).thenThrow(new IOException());
+
+      try {
+        writer.begin();
+      } catch (IOException ignored) {
+      }
+
+      verify(conn).disconnect();
     }
-    return data != null ? data.toString() : "{}";
+
+    @Test public void shouldFailSilentlyOnBadUrl() throws IOException {
+
+      writer.begin();
+      verify(url).openConnection();
+      verify(conn).getOutputStream();
+    }
+
+    @Test public void shouldConfigureConnectionOnBegin() throws IOException {
+      config.header.put("test-header", "test-header-value");
+      writer.begin();
+      verify(conn).setRequestMethod("POST");
+      verify(conn).setRequestProperty("test-header", "test-header-value");
+      verify(conn).setUseCaches(false);
+      verify(conn).setDoInput(false);
+      verify(conn).setDoOutput(true);
+    }
+
+    // writing
+
+    @Rule public TestData emptyJson = new TestData("no_measurement.json");
+
+    @Test public void shouldWriteConfigAndEnvInfo() throws IOException, JSONException {
+      writer.begin();
+      writer.end();
+
+      String writtenJson = trimAppMemDetails(extractWrittenString(outputStream));
+      JSONAssert.assertEquals(emptyJson.content, writtenJson, true);
+    }
+
+    @Rule public TestData emptyNoEnvJson = new TestData("no_measurement_no_env.json");
+
+    @Test public void shouldHandleNullsInEnvInfo() throws IOException, JSONException {
+      envInfo.device = null;
+      envInfo.network = null;
+
+      writer.begin();
+      writer.end();
+
+      String writtenJson = trimAppMemDetails(extractWrittenString(outputStream));
+      JSONAssert.assertEquals(emptyNoEnvJson.content, writtenJson, true);
+    }
+
+    @Rule public TestData metricJson = new TestData("metric.json");
+
+    @Test public void shouldWriteSingleMetric() throws IOException, JSONException {
+      Metric metric = new Metric();
+      metric.startTime = 0L;
+      metric.endTime = 999;
+      metric.id = "test-metric";
+      metric.urls = 999;
+
+      writer.begin();
+      writer.write(metric);
+      writer.end();
+
+      String writtenString = trimAppMemDetails(extractWrittenString(outputStream));
+      JSONAssert.assertEquals(metricJson.content, writtenString, true);
+    }
+
+    @Rule public TestData methodMeasurementJson = new TestData("method_measurement.json");
+
+    @Test public void shouldWriteSingleMethodMeasurement() throws JSONException, IOException {
+      Measurement measurement = new Measurement();
+      measurement.type = Measurement.METHOD;
+      measurement.a = "TestClass";
+      measurement.b = "testMethod";
+      measurement.startTime = 0L;
+      measurement.endTime = 999;
+
+      writer.begin();
+      writer.write(measurement, "test-metric");
+      writer.end();
+
+      String writtenString = trimAppMemDetails(extractWrittenString(outputStream));
+      JSONAssert.assertEquals(methodMeasurementJson.content, writtenString, true);
+    }
+
+    @Rule public TestData urlMeasurementJson = new TestData("url_measurement.json");
+
+    @Test public void shouldWriteUrlObjectMeasurement() throws JSONException, IOException {
+      Measurement measurement = new Measurement();
+      measurement.type = Measurement.URL;
+      measurement.a = new URL("https://rakuten.co.jp/some/path?and=some&url=params");
+      measurement.b = "VERB";
+      measurement.c = 200;
+      measurement.startTime = 0L;
+      measurement.endTime = 999;
+
+      writer.begin();
+      writer.write(measurement, "test-metric");
+      writer.end();
+
+      String writtenString = trimAppMemDetails(extractWrittenString(outputStream));
+      JSONAssert.assertEquals(urlMeasurementJson.content, writtenString, true);
+    }
+
+    @Test public void shouldWriteUrlStringMeasurement() throws JSONException, IOException {
+      Measurement measurement = new Measurement();
+      measurement.type = Measurement.URL;
+      measurement.a = "https://rakuten.co.jp/some/path?and=some&url=params";
+      measurement.b = "VERB";
+      measurement.c = 200;
+      measurement.startTime = 0L;
+      measurement.endTime = 999;
+
+      writer.begin();
+      writer.write(measurement, "test-metric");
+      writer.end();
+
+      String writtenString = trimAppMemDetails(extractWrittenString(outputStream));
+      JSONAssert.assertEquals(urlMeasurementJson.content, writtenString, true);
+    }
+
+    @Rule public TestData customMeasurementJson = new TestData("custom_measurement.json");
+
+    @Test public void shouldWriteSingleCustomMeasurement() throws JSONException, IOException {
+      Measurement measurement = new Measurement();
+      measurement.type = Measurement.CUSTOM;
+      measurement.a = "custom-measurement";
+      measurement.startTime = 0L;
+      measurement.endTime = 999;
+      measurement.activityName = "test-activity";
+
+      writer.begin();
+      writer.write(measurement, "test-metric");
+      writer.end();
+
+      String writtenString = trimAppMemDetails(extractWrittenString(outputStream));
+      JSONAssert.assertEquals(customMeasurementJson.content, writtenString, true);
+    }
+
+    @Rule public TestData escapedJson = new TestData("escaped.json");
+
+    @Test public void shouldHandleMalformedURLData() throws IOException, JSONException {
+      Measurement measurement = new Measurement();
+      measurement.type = Measurement.URL;
+      measurement.a = new URL("http://example.com:80/page1\".html");
+      measurement.startTime = 0L;
+      measurement.endTime = 999;
+
+      writer.begin();
+      writer.write(measurement, "test-metric");
+      measurement.a = new URL("http://example.com:80/page1\"[.html");
+      writer.write(measurement, "test-metric");
+      measurement.a = new URL("http://example.com:80/page1\"{.html");
+      writer.write(measurement, "test-metric");
+      measurement.a = new URL("http://example.com:80/page1\",.html");
+      writer.write(measurement, "test-metric");
+      measurement.a = new URL("http://example.com:80/page1'}'.html");
+      writer.write(measurement, "test-metric");
+      //For URL as String.
+      measurement.a = "http://example.com:80/page1\".html";
+      writer.write(measurement, "test-metric");
+      measurement.a = "http://example.com:80/page1\"[.html";
+      writer.write(measurement, "test-metric");
+      measurement.a = "http://example.com:80/page1\"{.html";
+      writer.write(measurement, "test-metric");
+      measurement.a = "http://example.com:80/page1\",.html";
+      writer.write(measurement, "test-metric");
+      measurement.a = "http://example.com:80/page1'}'.html";
+      writer.write(measurement, "test-metric");
+      writer.end();
+
+      String writtenString = trimAppMemDetails(extractWrittenString(outputStream));
+      JSONAssert.assertEquals(escapedJson.content, writtenString, true);
+    }
+
+    // smoke test
+
+    @Rule public TestData smokeTestJson = new TestData("smoke_test.json");
+
+    @Test public void smokeTest() throws IOException, JSONException {
+      Metric metric = new Metric();
+      metric.startTime = 0L;
+      metric.endTime = 999;
+      metric.id = "test-metric";
+      metric.urls = 999;
+
+      writer.begin();
+      writer.write(metric);
+      writer.write(metric);
+
+      Measurement measurement = new Measurement();
+      measurement.type = Measurement.METHOD;
+      measurement.a = "TestClass";
+      measurement.b = "testMethod";
+      measurement.startTime = 1L;
+      measurement.endTime = 999;
+
+      writer.write(measurement, metric.id);
+
+      measurement = new Measurement();
+      measurement.type = Measurement.URL;
+      measurement.a = "https://rakuten.co.jp1/some/path?and=some&url=params";
+      measurement.b = "VERB";
+      measurement.startTime = 10L;
+      measurement.endTime = 999;
+
+      writer.write(measurement, metric.id);
+
+      measurement = new Measurement();
+      measurement.type = Measurement.URL;
+      measurement.a = "https://rakuten.co.jp2/some/path?and=some&url=params";
+      measurement.b = "VERB";
+      measurement.startTime = 11L;
+      measurement.endTime = 999;
+
+      writer.write(measurement, null);
+
+      measurement = new Measurement();
+      measurement.type = Measurement.URL;
+      measurement.a = "https://rakuten.co.jp3/some/path?and=some&url=params";
+      measurement.b = null;
+      measurement.startTime = 100L;
+      measurement.endTime = 999;
+
+      writer.write(measurement, null);
+
+      measurement = new Measurement();
+      measurement.type = Measurement.CUSTOM;
+      measurement.a = "custom-measurement";
+      measurement.startTime = 101L;
+      measurement.endTime = 999;
+
+      writer.write(measurement, metric.id);
+
+      measurement = new Measurement();
+      measurement.type = Measurement.URL;
+      measurement.a = new URL("https://amazon.co.jp/other/path?and=some&url=params");
+      measurement.b = "BERV";
+      measurement.startTime = 0L;
+      measurement.endTime = 100;
+
+      writer.write(measurement, metric.id);
+
+      writer.end();
+
+      String writtenString = trimAppMemDetails(extractWrittenString(outputStream));
+      JSONAssert.assertEquals(smokeTestJson.content, writtenString, true);
+    }
+
+    // helpers
+
+    private String extractWrittenString(OutputStream outputStream) throws IOException {
+      ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
+      verify(outputStream).write(captor.capture(), anyInt(), anyInt());
+      byte[] writtenBytes = captor.getValue();
+      assertThat(writtenBytes).isNotEmpty();
+      return new String(writtenBytes);
+    }
+
+    /**
+     * Removes a key with name `app_mem_used` and its value from the input string
+     * Due to limitation we couldn't mock Runtime class native methods.
+     * Because of this we cannot validate App used memory in unit test. So removing `app_mem_used` field from actual string.
+     *
+     * @param input String
+     * @return String
+     */
+    private static String trimAppMemDetails(String input) {
+      JSONObject data = null;
+      try {
+        data = new JSONObject(input);
+        data.remove("app_mem_used");
+      } catch (JSONException e) {
+        e.printStackTrace();
+      }
+      return data != null ? data.toString() : "{}";
+    }
+  }
+
+  public static class EventWriterExceptionHandlingSpec extends EventWriterSpec {
+
+    @Before
+    public void setup() {
+      writer = new EventWriter(config, envInfo, url);
+    }
+
+    @Test public void shouldNotFailOnBadUrl() {
+      try {
+        config.eventHubUrl = "usnteaueau";
+        writer = new EventWriter(config, envInfo);
+      } catch(Exception e) {
+        TestCase.fail();
+      }
+    }
+
+    @Test public void shouldNotFailOnGoodUrl() {
+      try {
+        config.eventHubUrl = "https://rakuten.co.jp";
+        writer = new EventWriter(config, envInfo);
+      } catch(Exception e) {
+        TestCase.fail();
+      }
+    }
+
+    @Test public void shouldNotFailOnWritingNull() {
+      try {
+        writer.write(null);
+        writer.write(null, null);
+
+        writer.begin();
+        writer.write(null);
+        writer.write(null, null);
+        writer.end();
+      } catch(Exception e) {
+        TestCase.fail();
+      }
+    }
+
+    @Test public void shouldNotFailOnWriteWithoutBegin() {
+      try {
+        Measurement measurement = new Measurement();
+        measurement.type = Measurement.CUSTOM;
+        measurement.a = "";
+        measurement.startTime = 0L;
+        measurement.endTime = 999;
+        writer.write(measurement, "");
+      } catch(Exception e) {
+        TestCase.fail();
+      }
+    }
+
+    @Test public void shouldNotFailOnNullPayload() {
+      try {
+        Measurement measurement = new Measurement();
+        measurement.type = Measurement.CUSTOM;
+        measurement.a = null;
+        measurement.b = null;
+        measurement.startTime = 0L;
+        measurement.endTime = 999;
+        writer.begin();
+        writer.write(measurement, null);
+        measurement.type = Measurement.METHOD;
+        writer.write(measurement, null);
+        measurement.type = Measurement.URL;
+        writer.write(measurement, null);
+        measurement.type = Measurement.METRIC;
+        writer.write(measurement, null);
+        measurement.type = 5; // invalid type
+        writer.write(measurement, null);
+
+        Metric metric = new Metric();
+        metric.startTime = 0L;
+        metric.endTime = 999;
+        metric.id = null;
+        metric.urls = 999;
+        writer.write(metric);
+        writer.end();
+      } catch(Exception e) {
+        TestCase.fail();
+      }
+    }
+
+    @Test public void shouldNotFailOnIncorrectEnd() {
+      try {
+        writer.end();
+        writer.begin();
+        writer.end();
+        writer.end();
+      } catch(Exception e) {
+        TestCase.fail();
+      }
+    }
+  }
+
+  public static class DisabledEventWriterBehaviorSpec extends EventWriterSpec {
+
+    @Before
+    public void setup() {
+      config.enablePerfTrackingEvents = false;
+
+      writer = new EventWriter(config, envInfo, url);
+    }
+
+    @Test
+    public void shouldNotMakeConnections() throws IOException {
+      writer.begin();
+      writer.end();
+
+      verify(url, never()).openConnection();
+      verify(conn, never()).disconnect();
+    }
+
+    @Test
+    public void shouldNotWriteEvents() throws IOException {
+      writer.begin();
+      writer.write(new Metric());
+      writer.write(new Measurement(), "metric_id");
+      writer.end();
+
+      verify(outputStream, never()).write(any(byte[].class), anyInt(), anyInt());
+    }
   }
 }

--- a/performance-tracking-core/src/test/java/com/rakuten/tech/mobile/perf/core/SenderThreadSpec.java
+++ b/performance-tracking-core/src/test/java/com/rakuten/tech/mobile/perf/core/SenderThreadSpec.java
@@ -168,6 +168,7 @@ public class SenderThreadSpec {
       config.debug = true;
       config.eventHubUrl = ""; // url injected via constructor
       config.header = new HashMap<>();
+      config.enablePerfTrackingEvents = true;
 
       envInfo = new EnvironmentInfo(ctx, location, batteryinfo);
       location.publish(new LocationData("test-land", "test-region"));

--- a/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/AnalyticsBroadcaster.java
+++ b/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/AnalyticsBroadcaster.java
@@ -22,6 +22,7 @@ class AnalyticsBroadcaster extends Analytics {
   @VisibleForTesting
   static final String ACTION = "jp.co.rakuten.sdtd.analytics.ExternalEvent";
   private final List<URL> blacklist;
+  private final boolean enabled;
 
   /**
    * Send event data to peer analytics module. If the app does not bundle a compatible analytics
@@ -60,8 +61,9 @@ class AnalyticsBroadcaster extends Analytics {
    * @param context Context that will be used for broadcasting
    * @param blacklist variable list of URL strings that will be used to blacklist broadcasts.
    */
-  AnalyticsBroadcaster(@NonNull Context context, String... blacklist) {
+  AnalyticsBroadcaster(@NonNull Context context, boolean enabled, String... blacklist) {
     this.context = new WeakReference<>(context);
+    this.enabled = enabled;
     this.blacklist = new ArrayList<>(blacklist.length);
     for (String url : blacklist) {
       try {
@@ -80,6 +82,10 @@ class AnalyticsBroadcaster extends Analytics {
    */
   @Override
   public void sendEvent(@NonNull String name, @Nullable Map<String, ?> data) {
+    if (!enabled) {
+      return;
+    }
+
     Context ctx = this.context.get();
     if (ctx != null) AnalyticsBroadcaster.sendEvent(ctx, name, data);
   }

--- a/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigurationResult.java
+++ b/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigurationResult.java
@@ -22,14 +22,27 @@ class ConfigurationResult implements Parcelable {
   @SerializedName("sendHeaders")
   private Map<String, String> header;
 
+  @SerializedName("modules")
+  private Map<String, String> modules;
+
+  private static final String ENABLE_PERFORMANCE_TRACKING_KEY = "enablePerformanceTracking";
+  private static final String ENABLE_RAT_KEY = "enableRat";
+
   private ConfigurationResult(Parcel in) {
     enablePercent = in.readDouble();
     enableNonMetricMeasurement = in.readByte() == 1;
     sendUrl = in.readString();
-    Bundle bundle = in.readBundle();
+
+    Bundle headerBundle = in.readBundle();
     header = new HashMap<>();
-    for (String key : bundle.keySet()) {
-      header.put(key, bundle.getString(key));
+    for (String key : headerBundle.keySet()) {
+      header.put(key, headerBundle.getString(key));
+    }
+
+    Bundle modulesBundle = in.readBundle();
+    modules = new HashMap<>();
+    for (String key : modulesBundle.keySet()) {
+      modules.put(key, modulesBundle.getString(key));
     }
   }
 
@@ -38,11 +51,18 @@ class ConfigurationResult implements Parcelable {
     dest.writeDouble(enablePercent);
     dest.writeByte((byte) (enableNonMetricMeasurement ? 1 : 0));
     dest.writeString(sendUrl);
-    Bundle bundle = new Bundle();
+
+    Bundle headerBundle = new Bundle();
     for (String key : header.keySet()) {
-      bundle.putString(key, header.get(key));
+      headerBundle.putString(key, header.get(key));
     }
-    dest.writeBundle(bundle);
+    dest.writeBundle(headerBundle);
+
+    Bundle moduleBundle = new Bundle();
+    for (String key : modules.keySet()) {
+      moduleBundle.putString(key, modules.get(key));
+    }
+    dest.writeBundle(moduleBundle);
   }
 
   @Override
@@ -69,6 +89,18 @@ class ConfigurationResult implements Parcelable {
 
   boolean shouldEnableNonMetricMeasurement() {
     return enableNonMetricMeasurement;
+  }
+
+  boolean shouldSendToPerfTracking() {
+    return (modules != null && modules.containsKey(ENABLE_PERFORMANCE_TRACKING_KEY))
+        ? Boolean.valueOf(modules.get(ENABLE_PERFORMANCE_TRACKING_KEY))
+        : true;
+  }
+
+  boolean shouldSendToAnalytics() {
+    return (modules != null && modules.containsKey(ENABLE_RAT_KEY))
+        ? Boolean.valueOf(modules.get(ENABLE_RAT_KEY))
+        : false;
   }
 
   String getSendUrl() {

--- a/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/RuntimeContentProvider.java
+++ b/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/RuntimeContentProvider.java
@@ -70,7 +70,7 @@ public class RuntimeContentProvider extends ContentProvider {
           config,
           locationStore.getObservable(),
           batteryInfoStore.getObservable(),
-          new AnalyticsBroadcaster(context, manifest.ratEndPoint()));
+          new AnalyticsBroadcaster(context, config.enableAnalyticsEvents, manifest.ratEndPoint()));
       Metric.start("_launch");
     }
     return false;
@@ -119,6 +119,8 @@ public class RuntimeContentProvider extends ContentProvider {
       config.enableNonMetricMeasurement = lastConfig.shouldEnableNonMetricMeasurement();
       config.eventHubUrl = lastConfig.getSendUrl();
       config.header = lastConfig.getHeader();
+      config.enablePerfTrackingEvents = lastConfig.shouldSendToPerfTracking();
+      config.enableAnalyticsEvents = lastConfig.shouldSendToAnalytics();
     }
 
     return config;

--- a/performance-tracking/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigurationResultSpec.java
+++ b/performance-tracking/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigurationResultSpec.java
@@ -28,6 +28,8 @@ public class ConfigurationResultSpec extends RobolectricUnitSpec {
     assertThat(response.shouldEnableNonMetricMeasurement())
         .isEqualTo(fromParcel.shouldEnableNonMetricMeasurement());
     assertThat(response.getSendUrl()).isEqualTo(fromParcel.getSendUrl());
+    assertThat(response.shouldSendToPerfTracking()).isEqualTo(fromParcel.shouldSendToPerfTracking());
+    assertThat(response.shouldSendToAnalytics()).isEqualTo(fromParcel.shouldSendToAnalytics());
     assertThat(response.describeContents()).isEqualTo(fromParcel.describeContents());
   }
 

--- a/performance-tracking/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/TrackingManagerSpec.java
+++ b/performance-tracking/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/TrackingManagerSpec.java
@@ -31,7 +31,7 @@ public class TrackingManagerSpec extends RobolectricUnitSpec {
   @Before
   public void init() {
     TrackingManager.initialize(
-        context, config, location, battery, new AnalyticsBroadcaster(context));
+        context, config, location, battery, new AnalyticsBroadcaster(context, true));
     manager = TrackingManager.INSTANCE;
     TrackerShadow.mockTracker = tracker;
   }
@@ -42,7 +42,7 @@ public class TrackingManagerSpec extends RobolectricUnitSpec {
   public void shouldCreateInstanceOnInit() {
     TrackingManager.INSTANCE = null;
     TrackingManager.initialize(
-        context, config, location, battery, new AnalyticsBroadcaster(context));
+        context, config, location, battery, new AnalyticsBroadcaster(context, true));
     assertThat(TrackingManager.INSTANCE).isNotNull();
   }
 
@@ -50,7 +50,7 @@ public class TrackingManagerSpec extends RobolectricUnitSpec {
   public void shouldCreateNewInstanceOnEveryInit() {
     TrackingManager previousInstance = TrackingManager.INSTANCE;
     TrackingManager.initialize(
-        context, config, location, battery, new AnalyticsBroadcaster(context));
+        context, config, location, battery, new AnalyticsBroadcaster(context, true));
     assertThat(previousInstance).isNotEqualTo(TrackingManager.INSTANCE);
   }
 

--- a/performance-tracking/src/test/resources/configuration-api-response-zero-percent.json
+++ b/performance-tracking/src/test/resources/configuration-api-response-zero-percent.json
@@ -6,5 +6,9 @@
     "BrokerProperties": "{\"PartitionKey\": \"com.rakuten.tech.mobile.perf.example/1.0.0\"}",
     "Content-Type": "application/atom+xml;type=entry;charset=utf-8"
   },
-  "sendUrl": "https://secrect.event.host.net/measurements/messages?timeout=5&api-version=2014-01"
+  "sendUrl": "https://secrect.event.host.net/measurements/messages?timeout=5&api-version=2014-01",
+  "modules": {
+    "enablePerformanceTracking": "true",
+    "enableRat": "true"
+  }
 }

--- a/performance-tracking/src/test/resources/configuration-api-response.json
+++ b/performance-tracking/src/test/resources/configuration-api-response.json
@@ -6,5 +6,9 @@
     "BrokerProperties": "{\"PartitionKey\": \"com.rakuten.tech.mobile.perf.example/1.0.0\"}",
     "Content-Type": "application/atom+xml;type=entry;charset=utf-8"
   },
-  "sendUrl": "https://secrect.event.host.net/measurements/messages?timeout=5&api-version=2014-01"
+  "sendUrl": "https://secrect.event.host.net/measurements/messages?timeout=5&api-version=2014-01",
+  "modules": {
+    "enablePerformanceTracking": "true",
+    "enableRat": "true"
+  }
 }


### PR DESCRIPTION
# Description 
I've added the enabled/disabled check within `AnalyticsBroadcaster` and `EventWriter`. I chose to add it to `EventWriter` rather than `Sender` or `SenderThread` because those classes also manage things like the `MeasurementBuffer`, so it could be more difficult and confusing to add it there. Also, `EventWriter` is the level where measurements are actually sent to the perf-tracking url, so  I think adding the check here makes the SDK more extensible if we wish to send Measurements elsewhere in the future. What do you think?

## Links
[APTT-674]

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
