### PR TITLE
fix: launch metric was not being sent in certain cases (i.e. after bu…

### DIFF
--- a/performance-tracking-core/src/main/java/com/rakuten/tech/mobile/perf/core/MeasurementBuffer.java
+++ b/performance-tracking-core/src/main/java/com/rakuten/tech/mobile/perf/core/MeasurementBuffer.java
@@ -7,51 +7,98 @@ class MeasurementBuffer {
   // Size must by a power of 2 so that Integer.MAX_VALUE is divisible by it
   static final int SIZE = 512;
 
-  final Measurement[] at = new Measurement[SIZE];
-  final AtomicInteger nextTrackingId = new AtomicInteger(1);
+  private final Measurement[] measurements = new Measurement[SIZE];
+  // Tracking id shouldn't be zero as zero has special purpose
+  private final AtomicInteger nextTrackingId = new AtomicInteger(1);
 
   MeasurementBuffer() {
     for (int i = 0; i < SIZE; i++) {
-      at[i] = new Measurement();
+      measurements[i] = new Measurement();
     }
   }
 
+  // Constructor for testing only
+  MeasurementBuffer(int firstTrackingId) {
+    this();
+    nextTrackingId.set(firstTrackingId);
+  }
+
+  /**
+   * Retrieves measurement at the provided {@code index}
+   *
+   * @param index to retrieve
+   * @return the measurement for the provided index
+   */
+  Measurement at(int index) {
+    return measurements[index];
+  }
+
+  /**
+   * Adds the next tracking id to the next buffer slot and returns the measurement for that slot
+   *
+   * @return the next measurement or null if the buffer is full
+   */
   Measurement next() {
     int id = nextTrackingId.getAndIncrement();
+    int nextIndex = indexForId(id);
 
-    if (id == 0) {
-      // Ensure id is not zero as zero has special purpose
-      id = nextTrackingId.getAndIncrement();
-    }
-
-    int index = id % SIZE;
-    if (index < 0) {
-      index += SIZE;
-    }
-
-    Measurement m = at[index];
-
-    if (m.trackingId != 0) {
+    if (at(nextIndex).trackingId != 0) {
       nextTrackingId.getAndDecrement();
       return null;
     }
 
-    m.trackingId = id;
+    Measurement measurement = measurements[nextIndex];
+    measurement.trackingId = id;
 
-    return m;
+    return measurement;
   }
 
+  /**
+   * Retrieves a measurement by tracking Id
+   *
+   * @param trackingId to retrieve
+   * @return measurement with the provided tracking id, or null if the tracking id doesn't exist
+   */
   Measurement getByTrackingId(int trackingId) {
-    int index = trackingId % SIZE;
+    Measurement measurement = measurements[indexForId(trackingId)];
+    if (measurement.trackingId == trackingId) {
+      return measurement;
+    }
+
+    return null;
+  }
+
+  /**
+   * Returns the count of measurements in the buffer from {@code startIndex}
+   *
+   * @param startIndex to count from
+   * @return count of measurements
+   */
+  int count(int startIndex) {
+    int id = nextTrackingId.get();
+    int endIndex = indexForId(id);
+
+    int count;
+
+    if (startIndex == endIndex && at(endIndex).trackingId != 0) {
+      count = SIZE;
+    } else {
+      count = endIndex - startIndex;
+      if (count < 0) {
+        count += SIZE;
+      }
+    }
+
+    return count;
+  }
+
+  private static int indexForId(int id) {
+    int index = id % SIZE;
+
     if (index < 0) {
       index += SIZE;
     }
 
-    Measurement m = at[index];
-    if (m.trackingId == trackingId) {
-      return m;
-    }
-
-    return null;
+    return index;
   }
 }

--- a/performance-tracking-core/src/test/java/com/rakuten/tech/mobile/perf/core/SenderThreadSpec.java
+++ b/performance-tracking-core/src/test/java/com/rakuten/tech/mobile/perf/core/SenderThreadSpec.java
@@ -231,8 +231,9 @@ public class SenderThreadSpec {
     Measurement next = buffer.next();
     next.type = Measurement.METRIC;
     for (int i = 0; i < count; i++) {
-      buffer.next().endTime = 10000000;
-      buffer.next().startTime = 1;
+      Measurement nextMeasurement = buffer.next();
+      nextMeasurement.endTime = 10000000;
+      nextMeasurement.startTime = 1;
     }
   }
 

--- a/performance-tracking-plugin/build.gradle
+++ b/performance-tracking-plugin/build.gradle
@@ -16,7 +16,7 @@ sourceSets {
 dependencies {
   implementation gradleApi()
   implementation localGroovy()
-  implementation 'com.android.tools.build:gradle:2.3.3'
+  implementation 'com.android.tools.build:gradle:3.1.0'
   implementation 'org.ow2.asm:asm-all:5.1'
 }
 

--- a/performance-tracking-plugin/src/test/resources/example_app
+++ b/performance-tracking-plugin/src/test/resources/example_app
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         jcenter()
-
+        maven { url 'https://dl.bintray.com/android/android-tools/' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'

--- a/performance-tracking-plugin/src/test/resources/example_app_ext_all_enabled
+++ b/performance-tracking-plugin/src/test/resources/example_app_ext_all_enabled
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         jcenter()
-
+        maven { url 'https://dl.bintray.com/android/android-tools/' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'

--- a/performance-tracking-plugin/src/test/resources/example_app_ext_missing_some_config
+++ b/performance-tracking-plugin/src/test/resources/example_app_ext_missing_some_config
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         jcenter()
+        maven { url 'https://dl.bintray.com/android/android-tools/' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.3'


### PR DESCRIPTION
… buffer is full)

This bug also existed in other cases but we didn't notice it because the Metric will be sent after another metric is started.

Also refactored the MeasurementBuffer and Sender to encapsulate the MeasurementBuffer more and remove certain checks that shouldn't be possible if the fields of the buffer are not accessible outside of the class.

# Description 
I also did some refactoring because I think that the old code made bugs like this hard to spot. It always takes me a while to analyze and figure out how the buffer and sender interact. So I tried to refactor it in a way that makes it more self explanatory (and encapsulates some of the logic and fields better). What do you think?

## Links
APTT-722

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
