### PR TITLE
fix: Change location API path to "." instead of "/"

### DIFF
--- a/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/GeoLocationApi.java
+++ b/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/GeoLocationApi.java
@@ -5,6 +5,6 @@ import retrofit2.http.GET;
 import retrofit2.http.Header;
 
 public interface GeoLocationApi {
-  @GET("/")
+  @GET(".")
   Call<GeoLocationResponse> location(@Header("Ocp-Apim-Subscription-Key") String subscriptionKey);
 }


### PR DESCRIPTION
# Description 
Using "/" as the endpoint causes RetroFit to overwrite the path on the base URL and just use the host, i.e. https://{host}/ However, a parameter is required by `@Get`, so it is suggested by Retrofit devs to use '.'. See here: https://github.com/square/retrofit/issues/1567#issuecomment-180115150

## Links
SDKCF-1235

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
