### PR TITLE
Add subscription key prefix

### DIFF
--- a/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/App.java
+++ b/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/App.java
@@ -15,9 +15,17 @@ public interface App {
   @MetaData(key = "com.rakuten.tech.mobile.perf.LocationUrlPrefix", value = BuildConfig.DEFAULT_LOCATION_URL_PREFIX)
   String locationUrlPrefix();
 
-  @MetaData(key = "com.rakuten.tech.mobile.relay.AppId")
+  @MetaData(key = "com.rakuten.tech.mobile.ras.AppId")
   String appId();
 
-  @MetaData(key = "com.rakuten.tech.mobile.relay.SubscriptionKey")
+  @MetaData(key = "com.rakuten.tech.mobile.ras.ProjectSubscriptionKey")
   String appKey();
+
+  @MetaData(key = "com.rakuten.tech.mobile.relay.AppId")
+  @Deprecated
+  String relayAppId();
+
+  @MetaData(key = "com.rakuten.tech.mobile.relay.SubscriptionKey")
+  @Deprecated
+  String relayAppKey();
 }

--- a/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigApi.java
+++ b/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigApi.java
@@ -11,7 +11,7 @@ interface ConfigApi {
   Call<ConfigurationResponse> config(
       @Path("app") String appId,
       @Path("version") String appVersion,
-      @Header("Ocp-Apim-Subscription-Key") String subscriptionKey,
+      @Header("apiKey") String subscriptionKey,
       @Query("sdk") String sdkVersion,
       @Query("country") String country,
       @Query("osVersion") String osVersion,

--- a/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigStore.java
+++ b/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigStore.java
@@ -89,7 +89,7 @@ class ConfigStore extends Store<ConfigurationResponse> {
     this.appId = relayAppId;
     this.res = context.getResources();
     this.prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE);
-    this.subscriptionKey = subscriptionKey;
+    this.subscriptionKey = "ras-" + subscriptionKey;
     this.api = api;
     getObservable().publish(readConfigFromCache());
     handler = new Handler(Looper.getMainLooper());

--- a/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/RuntimeContentProvider.java
+++ b/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/RuntimeContentProvider.java
@@ -37,26 +37,26 @@ public class RuntimeContentProvider extends ContentProvider {
     BatteryInfoStore batteryInfoStore = new BatteryInfoStore(context);
 
     App manifest = new AppManifestConfig(context);
+    String appKey = manifest.appKey().isEmpty() ? manifest.relayAppKey() : manifest.appKey();
+    String appId = manifest.appId().isEmpty() ? manifest.relayAppId() : manifest.appId();
 
-    if (TextUtils.isEmpty(manifest.appKey())) {
-      Log.d(TAG, "Cannot read metadata `com.rakuten.tech.mobile.perf.SubscriptionKey` from"
+    if (appKey.isEmpty()) {
+      Log.d(TAG, "Cannot read metadata `com.rakuten.tech.mobile.ras.ProjectSubscriptionKey` from"
           + "manifest, automated performance tracking will not work.");
     }
 
-    if (TextUtils.isEmpty(manifest.appId())) {
-      Log.d(TAG, "Cannot read metadata `com.rakuten.tech.mobile.relay.AppId` from"
+    if (appId.isEmpty()) {
+      Log.d(TAG, "Cannot read metadata `com.rakuten.tech.mobile.ras.AppId` from"
           + "manifest, automated performance tracking will not work.");
     }
 
-    ConfigStore configStore = new ConfigStore(context, manifest.appId(), manifest.appKey(),
-            manifest.configUrlPrefix());
+    ConfigStore configStore = new ConfigStore(context, appId, appKey, manifest.configUrlPrefix());
 
     // Read last config from cache
-    Config config = createConfig(context, configStore.getObservable().getCachedValue(),
-        manifest.appId());
+    Config config = createConfig(context, configStore.getObservable().getCachedValue(), appId);
     if (config != null) {
       LocationStore locationStore =
-          new LocationStore(context, manifest.appKey(), manifest.locationUrlPrefix());
+          new LocationStore(context, appKey, manifest.locationUrlPrefix());
       // Initialise Tracking Manager
       TrackingManager.initialize(
           context,

--- a/performance-tracking/src/main/java/com/rakuten/tech/mobile/relay/AppId.java
+++ b/performance-tracking/src/main/java/com/rakuten/tech/mobile/relay/AppId.java
@@ -1,0 +1,9 @@
+package com.rakuten.tech.mobile.relay;
+
+/**
+ * App Id which will be used with the API endpoint
+ *
+ * @deprecated You should use com.rakuten.tech.mobile.ras.AppId instead
+ */
+@Deprecated
+public class AppId {}

--- a/performance-tracking/src/main/java/com/rakuten/tech/mobile/relay/SubscriptionKey.java
+++ b/performance-tracking/src/main/java/com/rakuten/tech/mobile/relay/SubscriptionKey.java
@@ -1,0 +1,9 @@
+package com.rakuten.tech.mobile.relay;
+
+/**
+ * Subscription key for the API endpoint
+ *
+ * @deprecated You should use com.rakuten.tech.mobile.ras.ProjectSubscriptionKey instead
+ */
+@Deprecated
+public class SubscriptionKey {}

--- a/performance-tracking/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigStoreSpec.java
+++ b/performance-tracking/src/test/java/com/rakuten/tech/mobile/perf/runtime/internal/ConfigStoreSpec.java
@@ -84,6 +84,14 @@ public class ConfigStoreSpec extends RobolectricUnitSpec {
   }
 
   @Test
+  public void shouldAddRasPrefixToSubscriptionKey() throws InterruptedException {
+    configStore = new ConfigStore(context, appId, "test-subscription-key", api);
+
+    assertThat(server.takeRequest().getHeader("apiKey"))
+      .isEqualTo( "ras-test-subscription-key");
+  }
+
+  @Test
   public void shouldUseCachedConfigForInstanceCreation() throws JSONException {
     prefs.edit().putString("config_key", config.content).apply();
 


### PR DESCRIPTION
# Description 
Added the `ras-` prefix to the subscription key when sending requests to the Config endpoint. Also changed the meta-data key names to `com.rakuten.tech.mobile.ras.ProjectSubscriptionKey` and `com.rakuten.tech.mobile.ras.AppId` to be consistent with the other SDKs.

## Links
SDKCF-1247

# Checklist
- [s] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [s] I wrote/updated tests for new/changed code
- [s] I ran `./gradlew check` without errors
