### PR TITLE
build: Add compile dependencies to fix DocLava doc generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
           key: v1-{{ checksum "build.gradle" }}-{{ checksum  "performance-tracking/build.gradle" }}-{{ checksum  "performance-tracking-plugin/build.gradle" }}-{{ checksum  "performance-tracking-core/build.gradle" }}-{{ checksum  "performance-tracking-stubs/build.gradle" }}
       - run: git submodule update --init
       - run: ./gradlew check --info -s
+      - run: ./gradlew generateDoclava
       - save_cache:
           paths:
             - ~/.gradle

--- a/performance-tracking/build.gradle
+++ b/performance-tracking/build.gradle
@@ -88,6 +88,8 @@ pmd { // TODO: fix all findbugs warnings
   ignoreFailures = true
 }
 
+apply from: '../config/documentation/doclava/android.gradle'
+
 task checkUrlPrefixes {
   doLast {
     if (!project.hasProperty('DEFAULT_CONFIG_URL_PREFIX') ||

--- a/performance-tracking/build.gradle
+++ b/performance-tracking/build.gradle
@@ -57,6 +57,12 @@ dependencies {
   implementation "com.android.support:support-v4:${CONFIG.versions.android.libraries.support}"
   implementation 'com.squareup.retrofit2:retrofit:2.4.0'
 
+  // DocLava needs the javax.annotations.Nullable class (used by Retrofit), so findbugs is added
+  // to bring this to the classpath: https://stackoverflow.com/a/19031259
+  compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
+  // Doclava needs an annotation class from this package (used by Retrofit)
+  compileOnly 'org.codehaus.mojo:animal-sniffer-annotations:1.18'
+
   implementation 'com.rakuten.tech.mobile:manifest-config-annotations:0.1.0'
   annotationProcessor   'com.rakuten.tech.mobile:manifest-config-processor:0.1.0'
 


### PR DESCRIPTION
# Description 
Retrofit has compileOnly dependencies on FindBugs and animal-sniffer. Unfortunately, that means DocLava throws an error when trying to process their source because it can't find some classes. So these dependencies have been added here as compileOnly so doc generation will succeed.

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
