### PR TITLE
fix: Change max metric duration from float to int

### DIFF
--- a/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/App.java
+++ b/performance-tracking/src/main/java/com/rakuten/tech/mobile/perf/runtime/internal/App.java
@@ -16,7 +16,7 @@ public interface App {
   String locationUrlPrefix();
 
   @MetaData(key = "com.rakuten.tech.mobile.perf.MaxMetricDuration", value = "10000")
-  float maxMetricDuration();
+  int maxMetricDuration();
 
   @MetaData(key = "com.rakuten.tech.mobile.ras.AppId")
   String appId();


### PR DESCRIPTION
# Description 
I'm not sure why I used float in the first place (the annotation processor only supports float and int). But using a float means that users will need to define the value with a decimal point, which doesn't make sense because the value is in milliseconds.

## Links

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [x] I ran `./gradlew check` without errors
